### PR TITLE
pkgs: automatic source management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@
 # Introduction
 DevOS grants a simple way to use, deploy and manage [NixOS][nixos] systems for
 personal and productive use. It does this by providing a convenient repository
-structure; integrating several popular projects like
-[home-manager][home-manager], and [devshell][devshell].
+structure, integrating several popular projects like
+[home-manager][home-manager], and [devshell][devshell], and offering useful
+conveniences like
+[automatic source updates](./pkgs#automatic-source-updates).
 
 Skip the indeterminate nature of other systems, _and_ the perceived difficulty
 of Nix. It's easier than you think!

--- a/doc/flk/update.md
+++ b/doc/flk/update.md
@@ -4,3 +4,13 @@ The `update` subcommand is a simple alias for:
 nix flake update --recreate-lock-file --commit-lock-file
 ```
 As it sounds, this will update your lock file, and commit it.
+
+## Updating Package Sources
+If you pass an input name then it will only update that input.
+
+For example, you can update any
+[package sources](../../pkgs#automatic-source-updates) you may have declared
+in _pkgs/flake.nix_:
+```sh
+flk update srcs
+```

--- a/flake.lock
+++ b/flake.lock
@@ -214,7 +214,19 @@
         "nixos-hardware": "nixos-hardware",
         "nur": "nur",
         "override": "override",
+        "srcs": "srcs",
         "utils": "utils"
+      }
+    },
+    "srcs": {
+      "locked": {
+        "narHash": "sha256-Ot96/oKT5+A5kdqkfYyT45cfEiqhI5UyPdEfEZjbXaA=",
+        "path": "./pkgs",
+        "type": "path"
+      },
+      "original": {
+        "path": "./pkgs",
+        "type": "path"
       }
     },
     "utils": {

--- a/flake.lock
+++ b/flake.lock
@@ -74,15 +74,16 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1606424373,
-        "narHash": "sha256-oq8d4//CJOrVj+EcOaSXvMebvuTkmBJuT5tzlfewUnQ=",
-        "owner": "edolstra",
+        "lastModified": 1611461076,
+        "narHash": "sha256-ad++dTtMNeitUIKi1c66aTrVJOSf+mdZTrGrXzjDr6Q=",
+        "owner": "BBBSnowball",
         "repo": "flake-compat",
-        "rev": "99f1c2157fba4bfe6211a321fd0ee43199025dbf",
+        "rev": "a565cb46bee9fa856a6c15bc9c3bb947fbb784ec",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "BBBSnowball",
+        "ref": "pr-1",
         "repo": "flake-compat",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
       naersk.inputs.nixpkgs.follows = "override";
       flake-compat.url = "github:edolstra/flake-compat";
       flake-compat.flake = false;
+      srcs.url = "path:./pkgs";
     };
 
   outputs =

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       deploy.inputs.flake-compat.follows = "flake-compat";
       naersk.url = "github:nmattia/naersk";
       naersk.inputs.nixpkgs.follows = "override";
-      flake-compat.url = "github:edolstra/flake-compat";
+      flake-compat.url = "github:BBBSnowball/flake-compat/pr-1";
       flake-compat.flake = false;
       srcs.url = "path:./pkgs";
     };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -4,7 +4,7 @@ let
     pathExists filter;
 
   inherit (nixos.lib) fold filterAttrs hasSuffix mapAttrs' nameValuePair removeSuffix
-    recursiveUpdate genAttrs nixosSystem mkForce optionalAttrs;
+    recursiveUpdate genAttrs nixosSystem mkForce substring optionalAttrs;
 
   # mapFilterAttrs ::
   #   (name -> value -> bool )
@@ -93,6 +93,8 @@ in
 
   overlays = pathsToImportedAttrs overlayPaths;
 
+  mkVersion = src: "${substring 0 8 src.lastModifiedDate}_${src.shortRev}";
+
   genPkgs = { self }:
     let inherit (self) inputs;
     in
@@ -107,6 +109,7 @@ in
             (overridesOverlay overridePkgs)
             self.overlay
             (final: prev: {
+              srcs = self.inputs.srcs.inputs;
               lib = (prev.lib or { }) // {
                 inherit (nixos.lib) nixosSystem;
                 flk = self.lib;

--- a/pkgs/README.md
+++ b/pkgs/README.md
@@ -14,22 +14,24 @@ the supported systems listed in the package's `meta.platforms` attribute.
 And, as usual, every package in the overlay is also available to any NixOS
 [host](../hosts).
 
+## Automatic Source Updates
+There is the added, but optional, convenience of declaring your sources in
+_pkgs/flake.nix_ as an input. This allows updates to be managed automatically
+by simply [updating](../doc/flk/update.md#updating-package-sources) the lock
+file. No more manually entering sha256 hashes!
+
+
 ## Example
 pkgs/development/libraries/libinih/default.nix:
 ```nix
-{ stdenv, meson, ninja, fetchFromGitHub, ... }:
-let version = "r50";
+{ stdenv, meson, ninja, lib, srcs, ... }:
+let version = "r53";
 in
 stdenv.mkDerivation {
   pname = "libinih";
   inherit version;
 
-  src = fetchFromGitHub {
-    owner = "benhoyt";
-    repo = "inih";
-    rev = "${version}";
-    hash = "sha256-GF+TVEysaXJxSBBjMsTr2IQvRKlzdEu3rlPQ88PE3nI=";
-  };
+  src = srcs.libinih;
 
   buildInputs = [ meson ninja ];
 
@@ -38,7 +40,7 @@ stdenv.mkDerivation {
     -Ddistro_install=true
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Simple .INI file parser in C";
     homepage = "https://github.com/benhoyt/inih";
     maintainers = [ maintainers.divnix ];
@@ -53,6 +55,18 @@ pkgs/default.nix:
 ```nix
 final: prev: {
   libinih = prev.callPackage ./development/libraries/libinih { };
+}
+```
+
+pkgs/flake.nix:
+```nix
+{
+  description = "Package sources";
+
+  inputs = {
+    libinih.url = "github:benhoyt/inih/r53";
+    libinih.flake = false;
+  };
 }
 ```
 

--- a/pkgs/flake.nix
+++ b/pkgs/flake.nix
@@ -1,0 +1,7 @@
+{
+  description = "Package sources";
+
+  inputs = { };
+
+  outputs = { ... }: { };
+}

--- a/shell/flk.sh
+++ b/shell/flk.sh
@@ -17,12 +17,12 @@ usage () {
 
   printf "  %-30s %s\n\n" \
   "up" "Generate $DEVSHELL_ROOT/hosts/up-$HOSTNAME.nix" \
-  "update" "Update and commit the lock file" \
-  "get [core|community] DEST" "Copy the desired template to DEST" \
+  "update [INPUT]" "Update and commit the lock file" \
+  "get (core|community) [DEST]" "Copy the desired template to DEST" \
   "iso HOST" "Generate an ISO image of HOST" \
   "install HOST [ARGS]" "Shortcut for nixos-install" \
   "home HOST USER [switch]" "Home-manager config of USER from HOST" \
-  "HOST [switch|boot|test]" "Shortcut for nixos-rebuild"
+  "HOST (switch|boot|test)" "Shortcut for nixos-rebuild"
 }
 
 case "$1" in
@@ -49,14 +49,18 @@ case "$1" in
     ;;
 
   "update")
-    nix flake update --recreate-lock-file --commit-lock-file "$DEVSHELL_ROOT"
+    if [[ -n "$2" ]]; then
+      nix flake update --update-input "$2" --commit-lock-file "$DEVSHELL_ROOT"
+    else
+      nix flake update --recreate-lock-file --commit-lock-file "$DEVSHELL_ROOT"
+    fi
     ;;
 
   "get")
     if [[ "$2" == "core" || "$2" == "community" ]]; then
       nix flake new -t "github:divnix/devos/$2" "${3:-flk}"
     else
-      echo "flk get [core|community] {dest}"
+      echo "flk get (core|community) [DEST]"
       exit 1
     fi
     ;;


### PR DESCRIPTION
Fixes #118.

- [x] Leverage flakes to manage package sources & hashes
- [x] Update documentation with an example.
- [x] Add `mkVersion` function to autogenerate a version string
- [x] Add srcs package via overlay containing all sources defined in  _pkgs/flake.nix_
- [x] Extend `flk update` with the ability to only update the given input
- [x] Fix flake-compat support 

Would appreciate any feedback before finalizing. 

My only nitpick is that I'd love to add the ability for `mkVersion` to pull a flake urls ref if one is given. For example, a flake url "github:owner/repo/version-tag" would generate the version: "version-tag". Doesn't seem like flake inputs keep the original ref though, only the sha, so we can't do this without parsing the lock file, or potentially filing an issue upstream to include this information.

> ##### _Note:_
> ~~This will break hercules-ci, since it currently relies on flake-compat, and this technique [breaks](https://discourse.nixos.org/t/possibility-for-subflakes/11589/6) flake-compat. So I'm kinda hesitant to merge unless a workaround is found.~~

/cc @benneti  @blaggacao @Pacman99 