### PR TITLE
profiles: simplify profiles to suites

### DIFF
--- a/hosts/NixOS.nix
+++ b/hosts/NixOS.nix
@@ -1,7 +1,7 @@
 { suites, ... }:
 {
   ### root password is empty by default ###
-  imports = suites.core;
+  imports = suites.base;
 
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -23,7 +23,7 @@ let
 
       modules =
         let
-          core = import ../profiles/core;
+          core = ../profiles/core;
 
           modOverrides = { config, overrideModulesPath, ... }:
             let

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -5,14 +5,16 @@ window manager. If you need some concrete examples, just checkout the
 community [branch](https://github.com/divnix/devos/tree/community/profiles).
 
 ## Constraints
-For the sake of consistency, there are a few minor constraints. First of all, a
-profile should always be defined in a `default.nix`, and it should always be a
-a function taking a single attribute set as an argument, and returning a NixOS
-module which does not define any new module options. If you need to make new
-module option declarations, just use [modules](../modules).
+For the sake of consistency, a profile should always be defined in a
+_default.nix_ containing a valid [nixos module](https://nixos.wiki/wiki/Module)
+which ___does not___ declare any new
+[module options](https://nixos.org/manual/nixos/stable/index.html#sec-option-declarations).
+If you need to do that, use the [modules directory](../modules).
 
-These restrictions help simplify the import logic used to pass profles to
-[suites](../suites).
+> ##### _Note:_
+> [hercules-ci](../doc/integrations/hercules.md) expects all profiles to be
+> defined in a _default.nix_. Similarly, [suites](../suites) expect a
+> _default.nix_ as well.
 
 ### Example
 #### Correct ✔
@@ -39,6 +41,25 @@ personal development environment, and the subprofiles should be more concrete
 program configurations such as your text editor, and shell configs. This way,
 you can either pull in the whole development profile, or pick and choose
 individual programs.
+
+### Example
+
+profiles/develop/default.nix:
+```nix
+{
+  imports = [ ./zsh ];
+  # some generic development concerns ...
+}
+```
+
+profiles/develop/zsh/default.nix:
+```nix
+{  ... }:
+{
+  programs.zsh.enable = true;
+  # zsh specific options ...
+}
+```
 
 ## Conclusion
 Profiles are the most important concept in devos. They allow us to keep our

--- a/profiles/user
+++ b/profiles/user
@@ -1,1 +1,0 @@
-../users/profiles

--- a/suites/default.nix
+++ b/suites/default.nix
@@ -1,24 +1,24 @@
 { lib }:
 let
   inherit (builtins) mapAttrs isFunction;
-  inherit (lib.flk) importDefaults;
+  inherit (lib.flk) mkProfileAttrs profileMap;
 
-  profiles = importDefaults (toString ../profiles);
-  users = importDefaults (toString ../users);
+  profiles = mkProfileAttrs (toString ../profiles);
+  users = mkProfileAttrs (toString ../users);
 
   allProfiles =
-    let
-      sansCore = lib.filterAttrs (n: _: n != "core") profiles;
-    in
-    lib.collect isFunction sansCore;
+    let defaults = lib.collect (x: x ? default) profiles;
+    in map (x: x.default) defaults;
 
-  allUsers = lib.collect isFunction users;
+  allUsers =
+    let defaults = lib.collect (x: x ? default) users;
+    in map (x: x.default) defaults;
 
 
   suites = with profiles; rec {
-    core = [ users.nixos users.root ];
+    base = [ users.nixos users.root ];
   };
 in
-mapAttrs (_: v: lib.flk.profileMap v) suites // {
+mapAttrs (_: v: profileMap v) suites // {
   inherit allProfiles allUsers;
 }


### PR DESCRIPTION
- [x] Leave importing to nixpkgs module implentation. Provide a path instead; resolves #136.
- [x] Allow profiles which are not lambdas but simple attribute sets, relaxing the constraints a bit.
- [x] Update profile README.md
- [x] defaultImports -> mkProfileAttrs: allow importing subprofiles even if parent directory does not contain a default.nix.