### PR TITLE
hosts: fix #142

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -64,20 +64,12 @@ let
 
                 nixos = {
                   exact = true;
-                  from = nodes.nixos.original;
+                  from = {
+                    id = "nixos";
+                    type = "indirect";
+                  };
                   to = {
                     inherit (nixos) lastModified narHash rev;
-
-                    path = override.outPath;
-                    type = "path";
-                  };
-                };
-
-                override = {
-                  exact = true;
-                  from = nodes.override.original;
-                  to = {
-                    inherit (override) lastModified narHash rev;
 
                     path = override.outPath;
                     type = "path";


### PR DESCRIPTION
Get rid of the problematic entries, but keep `nixos` as a shortcut for the current `nixos` devos input. (e. g. `nix build nixos#firefox`). Resolves #142