### PR TITLE
Expose namespaced lib on pkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
               inherit (pkgs) lib;
             });
 
-          overlay = import ./pkgs;
+          overlay = import ./pkgs { inherit nixos; };
 
           lib = import ./lib { inherit nixos pkgs; };
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -82,6 +82,15 @@ lib/default.nix:
 }
 ```
 
+You can then access this library function via `pkgs.myLib`:
+
+```nix
+{ pkgs, ... }:
+
+pkgs.myLib.mkCustomI3BindSym { "..." };
+
+```
+
 [nixpkgs-lib]: https://github.com/NixOS/nixpkgs/tree/master/lib
 [nixpkgs-pkgs-lib]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/pkgs-lib
 [nixpkgs-pkgs-build-support]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/build-support

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,1 +1,3 @@
-final: prev: { }
+{ nixos }: final: prev: {
+  myLib = import ../lib { inherit nixos; pkgs = final; };
+}


### PR DESCRIPTION
I'm not 100% sure if the local library is already supercharged on `lib`, but also for sharing as an overlay I think a name spaced identifier is a better solution in any case.

Currently, I adopted `myLib`, but that should probably become `myname.lib` so that I can use library functions more cleanly from fellow devossers. Though, I didn't want to propose that together with this PR, since it is an independent change / discussion.