### PR TITLE
remove trailing newline of cmdline in mitigations.nix

### DIFF
--- a/modules/security/mitigations.nix
+++ b/modules/security/mitigations.nix
@@ -6,8 +6,7 @@ let
   cfg = config.security.mitigations;
 
   cmdline = ''
-    ibrs noibpb nopti nospectre_v2 nospectre_v1 l1tf=off nospec_store_bypass_disable no_stf_barrier mds=off tsx=on tsx_async_abort=off mitigations=off
-  '';
+    ibrs noibpb nopti nospectre_v2 nospectre_v1 l1tf=off nospec_store_bypass_disable no_stf_barrier mds=off tsx=on tsx_async_abort=off mitigations=off'';
 in
 {
   options = {


### PR DESCRIPTION
the trailing newline will push other kernel params to another line, leading to something like:

```
/boot/loader/entries/nixos-generation-67.conf:7: Unknown line "loglevel=4", ignoring.
```