### PR TITLE
Multi-arch support for hosts(nixosConfigurations)

### DIFF
--- a/hosts/README.md
+++ b/hosts/README.md
@@ -25,6 +25,10 @@ that you intend to use on your machine.
 Additionally, this is the perfect place to import anything you might need from
 the [nixos-hardware][nixos-hardware] repository.
 
+> ##### _Note:_
+> Set `nixpkgs.system` to the architecture of this host, default is "x86_64-linux". 
+> Keep in mind that not all packages are available for all architectures.
+
 ## Example
 
 hosts/librem.nix:

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -3,9 +3,9 @@
 , lib
 , nixos
 , override
-, pkgs
+, multiPkgs
 , self
-, system
+, defaultSystem
 , ...
 }:
 let
@@ -27,7 +27,7 @@ let
           modules;
       };
 
-    global = {
+    global = { config, ... }: {
       home-manager.useGlobalPkgs = true;
       home-manager.useUserPackages = true;
 
@@ -39,7 +39,7 @@ let
         "home-manager=${home}"
       ];
 
-      nixpkgs = { inherit pkgs; };
+      nixpkgs.pkgs = lib.mkDefault multiPkgs.${config.nixpkgs.system};
 
       nix.registry = {
         devos.flake = self;
@@ -79,7 +79,8 @@ let
       };
     in
     dev.os.devosSystem {
-      inherit system specialArgs;
+      inherit specialArgs;
+      system = defaultSystem;
       modules = modules // { inherit local lib; };
     };
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,4 +1,4 @@
-args@{ nixos, pkgs, self, ... }:
+args@{ nixos, self, ... }:
 let inherit (nixos) lib; in
 lib.makeExtensible (final:
   let callLibs = file: import file

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -59,45 +59,44 @@ let
     nixosTesting.makeTest calledTest;
 in
 {
-  x86_64-linux = {
-    profilesTest = mkTest {
-      name = "profiles";
+  profilesTest = mkTest {
+    name = "profiles";
 
-      machine = { suites, ... }: {
-        imports = suites.allProfiles ++ suites.allUsers;
-      };
-
-      testScript = ''
-        machine.systemctl("is-system-running --wait")
-      '';
+    machine = { suites, ... }: {
+      imports = suites.allProfiles ++ suites.allUsers;
     };
 
-    libTests = pkgs.runCommandNoCC "devos-lib-tests"
-      {
-        buildInputs = [
-          pkgs.nix
-          (
-            let tests = import ./lib.nix { inherit self pkgs; };
-            in
-            if tests == [ ]
-            then null
-            else throw (builtins.toJSON tests)
-          )
-        ];
-      } ''
-      datadir="${pkgs.nix}/share"
-      export TEST_ROOT=$(pwd)/test-tmp
-      export NIX_BUILD_HOOK=
-      export NIX_CONF_DIR=$TEST_ROOT/etc
-      export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
-      export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
-      export NIX_STATE_DIR=$TEST_ROOT/var/nix
-      export NIX_STORE_DIR=$TEST_ROOT/store
-      export PAGER=cat
-      cacheDir=$TEST_ROOT/binary-cache
-      nix-store --init
-
-      touch $out
+    testScript = ''
+      machine.systemctl("is-system-running --wait")
     '';
   };
+
+  libTests = pkgs.runCommandNoCC "devos-lib-tests"
+    {
+      buildInputs = [
+        pkgs.nix
+        (
+          let tests = import ./lib.nix { inherit self pkgs; };
+          in
+          if tests == [ ]
+          then null
+          else throw (builtins.toJSON tests)
+        )
+      ];
+    } ''
+    datadir="${pkgs.nix}/share"
+    export TEST_ROOT=$(pwd)/test-tmp
+    export NIX_BUILD_HOOK=
+    export NIX_CONF_DIR=$TEST_ROOT/etc
+    export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
+    export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
+    export NIX_STATE_DIR=$TEST_ROOT/var/nix
+    export NIX_STORE_DIR=$TEST_ROOT/store
+    export PAGER=cat
+    cacheDir=$TEST_ROOT/binary-cache
+    nix-store --init
+
+    touch $out
+  '';
 }
+


### PR DESCRIPTION
fixes #72 

also related, #125 

This allows users to set `nixpkgs.system` to any architecture exported by the nixpkgs flake and nixpkgs.pkgs will be set to that system.

I also added `multiPkgs` as a special arg and made `nixpkgs.pkgs` a default. So if someone wanted to do crossSystem builds or anything else with pkgs, that is also an option(eg. mobile-nixos!!).