### PR TITLE
add hosts module arg

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -75,6 +75,8 @@ let
 
         _module.args = {
           inherit self;
+          hosts = builtins.mapAttrs (_: host: host.config)
+            (removeAttrs hosts [ hostName ]);
         };
       };
     in


### PR DESCRIPTION
should help with #163. Fixes #169
But either way this could be generally useful. I have one use case of setting up a minecraft bungeecord proxy with servers on different hosts. 