### PR TITLE
doc: identify installation device

### DIFF
--- a/doc/start/iso.md
+++ b/doc/start/iso.md
@@ -8,4 +8,7 @@ dd bs=4M if=result/iso/*.iso of=/dev/$your_installation_device \
   status=progress oflag=sync
 ```
 
+_Note: You can use `lsblk` to better identify `$your_installation_device` and
+it's current partitions._
+
 This works for any file matching `hosts/*.nix` excluding `default.nix`.


### PR DESCRIPTION
Is this the best tool to check the `/dev/sd*`s & `/dev/mblk*`s, etc.?

It is, in any case, available in the nixos installer iso.