### PR TITLE
general: pass `self` to `./lib` & `./hosts`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
 
       extern = import ./extern { inherit inputs; };
 
-      pkgs' = os.mkPkgs { inherit self; };
+      pkgs' = os.mkPkgs;
 
       outputs =
         let
@@ -57,7 +57,7 @@
           overlay = import ./pkgs;
           overlays = lib.pathsToImportedAttrs (lib.pathsIn ./overlays);
 
-          lib = import ./lib { inherit nixos pkgs; };
+          lib = import ./lib { inherit nixos pkgs self; };
 
           templates.flk.path = ./.;
           templates.flk.description = "flk template";
@@ -79,16 +79,14 @@
         let pkgs = pkgs'.${system}; in
         {
           packages = utils.lib.flattenTreeSystem system
-            (os.mkPackages {
-              inherit self pkgs;
-            });
+            (os.mkPackages { inherit pkgs; });
 
           devShell = import ./shell {
             inherit self system;
           };
 
           legacyPackages.hmActivationPackages =
-            os.mkHomeActivation { inherit self; };
+            os.mkHomeActivation;
         }
       );
     in

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -72,6 +72,10 @@ let
         ];
 
         networking = { inherit hostName; };
+
+        _module.args = {
+          inherit self;
+        };
       };
     in
     dev.os.devosSystem {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,14 +1,14 @@
-args@{ nixos, pkgs, ... }:
+args@{ nixos, pkgs, self, ... }:
 let inherit (nixos) lib; in
-lib.makeExtensible (self:
+lib.makeExtensible (final:
   let callLibs = file: import file
     ({
       inherit lib;
 
-      dev = self;
+      dev = final;
     } // args);
   in
-  with self;
+  with final;
   {
     inherit callLibs;
 

--- a/lib/devos/mkHomeActivation.nix
+++ b/lib/devos/mkHomeActivation.nix
@@ -1,6 +1,5 @@
-{ lib, ... }:
+{ lib, self, ... }:
 
-{ self }:
 let hmConfigs =
   lib.mapAttrs
     (_: config: config.config.home-manager.users)

--- a/lib/devos/mkPackages.nix
+++ b/lib/devos/mkPackages.nix
@@ -1,6 +1,6 @@
-{ lib, dev, ... }:
+{ lib, dev, self, ... }:
 
-{ self, pkgs }:
+{ pkgs }:
 let
   inherit (self) overlay overlays;
   packagesNames = lib.attrNames (overlay null null)

--- a/lib/devos/mkPkgs.nix
+++ b/lib/devos/mkPkgs.nix
@@ -1,6 +1,5 @@
-{ lib, dev, nixos, ... }:
+{ lib, dev, nixos, self, ... }:
 
-{ self }:
 let inherit (self) inputs;
 in
 (inputs.utils.lib.eachDefaultSystem

--- a/shell/default.nix
+++ b/shell/default.nix
@@ -2,7 +2,7 @@
 , system ? builtins.currentSystem
 }:
 let
-  pkgs = (self.lib.os.mkPkgs { inherit self; }).${system};
+  pkgs = (self.lib.os.mkPkgs).${system};
 
   inherit (pkgs) lib;
 


### PR DESCRIPTION
It is generally useful to acess the top level flake from
library functions or hosts. This not only simplifies
the mental model and code but also provides additional
context and not least a handle to the repo source code
in the nix store.

closes #169

bors delegate=@Pacman99