### PR TITLE
iso: only include the host's dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 **Documentation:**
 
+- doc: split iso [\#193](https://github.com/divnix/devos/issues/193)
 - lib: can depend on pkgs \(a la nixpkgs\#pkgs/pkgs-lib\) [\#147](https://github.com/divnix/devos/pull/147)
 
 **Closed issues:**
@@ -36,6 +37,7 @@
 
 **Merged pull requests:**
 
+- doc: enact bootstrapping section [\#196](https://github.com/divnix/devos/pull/196)
 - iso: copy input closourse into iso to avoide re-download [\#191](https://github.com/divnix/devos/pull/191)
 - add hosts module arg [\#164](https://github.com/divnix/devos/pull/164)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 **Merged pull requests:**
 
+- hosts/devosSystem: pass modules as attrset [\#198](https://github.com/divnix/devos/pull/198)
 - doc: enact bootstrapping section [\#196](https://github.com/divnix/devos/pull/196)
 - iso: copy input closourse into iso to avoide re-download [\#191](https://github.com/divnix/devos/pull/191)
 - add hosts module arg [\#164](https://github.com/divnix/devos/pull/164)

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -4,12 +4,13 @@
 lib.nixosSystem (args // {
   modules =
     let
+      moduleList = builtins.attrValues modules;
       modpath = "nixos/modules";
       cd = "installer/cd-dvd/installation-cd-minimal-new-kernel.nix";
 
       isoConfig = (lib.nixosSystem
         (args // {
-          modules = modules ++ [
+          modules = moduleList ++ [
             "${nixos}/${modpath}/${cd}"
             ({ config, ... }: {
               isoImage.isoBaseName = "nixos-" + config.networking.hostName;
@@ -58,7 +59,7 @@ lib.nixosSystem (args // {
           ];
         })).config;
     in
-    modules ++ [{
+    moduleList ++ [{
       system.build = {
         iso = isoConfig.system.build.isoImage;
       };

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -8,6 +8,8 @@ lib.nixosSystem (args // {
       modpath = "nixos/modules";
       cd = "installer/cd-dvd/installation-cd-minimal-new-kernel.nix";
 
+      hostConfig = (lib.nixosSystem (args // { modules = moduleList; })).config;
+
       isoConfig = (lib.nixosSystem
         (args // {
           modules = moduleList ++ [
@@ -21,7 +23,10 @@ lib.nixosSystem (args // {
               nix.registry = lib.mapAttrs (n: v: { flake = v; }) inputs;
               isoImage.storeContents = [
                 self.devShell.${config.nixpkgs.system}
+                hostConfig.system.build.toplevel
+                hostConfig.system.build.toplevel.drvPath
               ];
+              environment.systemPackages = hostConfig.environment.systemPackages;
               # confilcts with networking.wireless which might be slightly
               # more useful on a stick
               networking.networkmanager.enable = lib.mkForce false;

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -10,11 +10,14 @@ lib.nixosSystem (args // {
 
       hostConfig = (lib.nixosSystem (args // { modules = moduleList; })).config;
 
+      isoModules = (builtins.attrValues (builtins.removeAttrs modules [ "local" "lib" ]));
+
       isoConfig = (lib.nixosSystem
         (args // {
-          modules = moduleList ++ [
+          modules = isoModules ++ [
             "${nixos}/${modpath}/${cd}"
-            ({ config, ... }: {
+            ({ config, suites, ... }: {
+              imports = suites.base;
               isoImage.isoBaseName = "nixos-" + config.networking.hostName;
               isoImage.contents = [{
                 source = self;

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -25,9 +25,7 @@ lib.nixosSystem (args // {
               nix.registry = lib.mapAttrs (n: v: { flake = v; }) inputs;
               isoImage.storeContents = [
                 self.devShell.${config.nixpkgs.system}
-                self.devShell.${config.nixpkgs.system}.drvPath
                 hostConfig.system.build.toplevel
-                hostConfig.system.build.toplevel.drvPath
               ];
               environment.systemPackages = hostConfig.environment.systemPackages;
 

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -31,7 +31,6 @@ lib.nixosSystem (args // {
               ];
               environment.systemPackages = hostConfig.environment.systemPackages;
 
-              networking.hostName = hostConfig.networking.hostName;
               # confilcts with networking.wireless which might be slightly
               # more useful on a stick
               networking.networkmanager.enable = lib.mkForce false;

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -26,6 +26,7 @@ lib.nixosSystem (args // {
               nix.registry = lib.mapAttrs (n: v: { flake = v; }) inputs;
               isoImage.storeContents = [
                 self.devShell.${config.nixpkgs.system}
+                self.devShell.${config.nixpkgs.system}.drvPath
                 hostConfig.system.build.toplevel
                 hostConfig.system.build.toplevel.drvPath
               ];

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -10,14 +10,13 @@ lib.nixosSystem (args // {
 
       hostConfig = (lib.nixosSystem (args // { modules = moduleList; })).config;
 
-      isoModules = (builtins.attrValues (builtins.removeAttrs modules [ "local" "lib" ]));
-
       isoConfig = (lib.nixosSystem
         (args // {
-          modules = isoModules ++ [
+          modules = moduleList ++ [
             "${nixos}/${modpath}/${cd}"
             ({ config, suites, ... }: {
-              imports = suites.base;
+              disabledModules = lib.remove modules.core suites.allProfiles;
+
               isoImage.isoBaseName = "nixos-" + config.networking.hostName;
               isoImage.contents = [{
                 source = self;

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -31,6 +31,8 @@ lib.nixosSystem (args // {
                 hostConfig.system.build.toplevel.drvPath
               ];
               environment.systemPackages = hostConfig.environment.systemPackages;
+
+              networking.hostName = hostConfig.networking.hostName;
               # confilcts with networking.wireless which might be slightly
               # more useful on a stick
               networking.networkmanager.enable = lib.mkForce false;


### PR DESCRIPTION
fixes #194 

I've only tested that the iso build evaluates. I still have to test that it builds. And this change *could* break the current iso build, so it definitely has to be tested thoroughly. 

I came up with a pretty simple solution though, so I thought I may as well share it. Instead of importing all modules, I just added the hosts toplevel into the iso's storeContents.

cc @blaggacao 