### PR TITLE
hosts/devosSystem: pass modules as attrset

### DIFF
--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -4,12 +4,13 @@
 lib.nixosSystem (args // {
   modules =
     let
+      moduleList = builtins.attrValues modules;
       modpath = "nixos/modules";
       cd = "installer/cd-dvd/installation-cd-minimal-new-kernel.nix";
 
       isoConfig = (lib.nixosSystem
         (args // {
-          modules = modules ++ [
+          modules = moduleList ++ [
             "${nixos}/${modpath}/${cd}"
             ({ config, ... }: {
               isoImage.isoBaseName = "nixos-" + config.networking.hostName;
@@ -58,7 +59,7 @@ lib.nixosSystem (args // {
           ];
         })).config;
     in
-    modules ++ [{
+    moduleList ++ [{
       system.build = {
         iso = isoConfig.system.build.isoImage;
       };


### PR DESCRIPTION
This is a fairly simple change that only changes the lib api for devosSystem. But doesn't add any features by itself. Hosts now pass modules to devosSystem as an attrset. And devosSystem just grabs all modules in the set and passes it to nixosSystem. 

I plan to use this in #197 to selectively import modules. And I think it could help with nix-darwin - and other config systems - support, since not all profiles and modules are config system agnostic. This could be a workaround to add rudimentary support for other config systems by only importing the necessary modules.

Overall I think its a useful change and extends the abilities of `devosSystem`