### PR TITLE
iso: avoid systemd service startup

### DIFF
--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -7,6 +7,8 @@ lib.nixosSystem (args // {
       moduleList = builtins.attrValues modules;
       modpath = "nixos/modules";
 
+      fullHostConfig = (lib.nixosSystem (args // { modules = moduleList; })).config;
+
       isoConfig = (lib.nixosSystem
         (args // {
           modules = moduleList ++ [
@@ -27,6 +29,9 @@ lib.nixosSystem (args // {
               }];
               isoImage.storeContents = [
                 self.devShell.${config.nixpkgs.system}
+                # include also closures that are "switched off" by the
+                # above profile filter on the local config attribute
+                fullHostConfig.system.build.toplevel
               ];
 
               # confilcts with networking.wireless which might be slightly

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -33,6 +33,8 @@ lib.nixosSystem (args // {
                 # above profile filter on the local config attribute
                 fullHostConfig.system.build.toplevel
               ];
+              # still pull in tools of deactivated profiles
+              environment.systemPackages = fullHostConfig.environment.systemPackages;
 
               # confilcts with networking.wireless which might be slightly
               # more useful on a stick

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -12,7 +12,11 @@ lib.nixosSystem (args // {
         (args // {
           modules = moduleList ++ [
             "${nixos}/${modpath}/${cd}"
-            ({ config, ... }: {
+            ({ config, suites, ... }: {
+
+              # avoid unwanted systemd service startups
+              disabledModules = lib.remove modules.core suites.allProfiles;
+
               isoImage.isoBaseName = "nixos-" + config.networking.hostName;
               isoImage.contents = [{
                 source = self;

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -6,31 +6,35 @@ lib.nixosSystem (args // {
     let
       moduleList = builtins.attrValues modules;
       modpath = "nixos/modules";
-      cd = "installer/cd-dvd/installation-cd-minimal-new-kernel.nix";
 
       isoConfig = (lib.nixosSystem
         (args // {
           modules = moduleList ++ [
-            "${nixos}/${modpath}/${cd}"
+
+            "${nixos}/${modpath}/installer/cd-dvd/installation-cd-minimal-new-kernel.nix"
+
             ({ config, suites, ... }: {
 
               # avoid unwanted systemd service startups
               disabledModules = lib.remove modules.core suites.allProfiles;
+
+              nix.registry = lib.mapAttrs (n: v: { flake = v; }) inputs;
 
               isoImage.isoBaseName = "nixos-" + config.networking.hostName;
               isoImage.contents = [{
                 source = self;
                 target = "/devos/";
               }];
-              nix.registry = lib.mapAttrs (n: v: { flake = v; }) inputs;
               isoImage.storeContents = [
                 self.devShell.${config.nixpkgs.system}
               ];
+
               # confilcts with networking.wireless which might be slightly
               # more useful on a stick
               networking.networkmanager.enable = lib.mkForce false;
               # confilcts with networking.wireless
               networking.wireless.iwd.enable = lib.mkForce false;
+
               # Set up a link-local boostrap network
               # See also: https://github.com/NixOS/nixpkgs/issues/75515#issuecomment-571661659
               networking.usePredictableInterfaceNames = lib.mkForce true; # so prefix matching works

--- a/lib/devos/mkProfileAttrs.nix
+++ b/lib/devos/mkProfileAttrs.nix
@@ -27,7 +27,7 @@ let mkProfileAttrs =
     f = n: _:
       lib.optionalAttrs
         (lib.pathExists "${dir}/${n}/default.nix")
-        { default = "${dir}/${n}"; }
+        { default = /. + "${dir}/${n}"; }
       // mkProfileAttrs "${dir}/${n}";
   in
   lib.mapAttrs f imports;


### PR DESCRIPTION
fixes #194
alternative to #197

# Manual Tests


<details>
<summary>was unrelated</summary>

- [ ] `flk install NixOS --impure` correctly onto `/mnt` :negative_squared_cross_mark: (looks like no profile is present)

Issue: https://github.com/divnix/devos/issues/204
Upstream Issue: https://github.com/NixOS/nixpkgs/issues/116938

</details>

- [x] acceptable build time / closure size ca 850MB (for a simple base OS) :heavy_check_mark: 
- [x] local profile with `cage` service is disabled, that is: boots into terminal :heavy_check_mark: 
- [x] success: air gapped / offline devshell enter :heavy_check_mark: 
- [ ] failure: aire gapped target install: &larr; non blocking bonus item :negative_squared_cross_mark: 
```console
$ flk install POS
warning: you don't have internet access; disabling some network-dependent features
building the flake in path:/iso/devos?narHash=sha265-...
warning: you don't have internet access; disabling some network-dependent features
error: unable to download 'https://api.github.com/repos/NixOS/nixpkgs/df8e3...': Couldn't resolve host name (6)
```

&rarr; detailed rationale in the commit messages

:heart: @Pacman99 for the excellent and detailed discussions in #197 and the may ideas, suggestions and code.