### PR TITLE
mkDevos and evalDevosArgs: Move flake implementation logic into lib

### DIFF
--- a/doc/start/index.md
+++ b/doc/start/index.md
@@ -36,6 +36,7 @@ In addition, the [binary cache](../../cachix) is added for faster deployment.
 - [Make installable ISO](./iso.md)
 - [Bootstrap Host](./bootstrapping.md)
 - [Already on NixOS](./from-nixos.md)
+- [Use mkDevos](./mkDevos.md)
 
 
 [install-nix]: https://nixos.org/manual/nix/stable/#sect-multi-user-installation

--- a/doc/start/use-mkdevos.md
+++ b/doc/start/use-mkdevos.md
@@ -1,0 +1,36 @@
+# Use mkDevos
+You can also use devos as a flake input and get the advantage of using
+nix flakes to sync with upstream changes in devos.
+
+To do this you will need the template and nix unstable. Edit your flake.nix to
+add devos as an input:
+```nix
+inputs = {
+  ...
+  devos.url = "github:divnix/devos";
+};
+```
+then replace the outputs section with this:
+```nix
+outputs = { self, devos, ... }: devos.lib.mkDevos { inherit self; };
+```
+
+Now you can update devos as you would any other flake input:
+```sh
+nix flake update --update-input devos
+```
+
+If you would like to change your directory's structure, you can pass
+arguments to `mkDevos` to outline where certain things are. You can take a 
+look at [evalDevosArgs](../../lib/devos/evalDevosArgs.nix) to learn about
+the arguments that it can take.
+
+> ##### Notes:
+> - All inputs used in devos must also be added to your flake, due to an
+>   [issue](https://github.com/NixOS/nix/pull/4641) with the `follows` attribute.
+> - Optionally, you can safely delete [lib](../../lib), [tests](../../tests) and
+>   the [core profile](../../profiles/core)
+> - You can append `/community` to the `devos.url` to get access to community modules
+>   which can be added in [extern](../../extern).
+> - To use community profiles, you will have to copy them to your tree
+> - If you use this method, you will no longer be able to edit devos internals.

--- a/doc/start/use-mkdevos.md
+++ b/doc/start/use-mkdevos.md
@@ -2,8 +2,13 @@
 You can also use devos as a flake input and get the advantage of using
 nix flakes to sync with upstream changes in devos.
 
-To do this you will need the template and nix unstable. Edit your flake.nix to
-add devos as an input:
+You can either use the default template or use the 'mkdevos' template which only
+includes the necessary files for `mkDevos` usage. It can be pulled with:
+```sh
+nix flake init -t github:divnix/devos#mkdevos
+```
+
+Once you have a template, edit your flake.nix to add devos as an input:
 ```nix
 inputs = {
   ...
@@ -15,10 +20,7 @@ then replace the outputs section with this:
 outputs = { self, devos, ... }: devos.lib.mkDevos { inherit self; };
 ```
 
-Now you can update devos as you would any other flake input:
-```sh
-nix flake update --update-input devos
-```
+Now you can sync with upstream devos changes just like any other flake input.
 
 If you would like to change your directory's structure, you can pass
 arguments to `mkDevos` to outline where certain things are. You can take a 
@@ -28,9 +30,8 @@ the arguments that it can take.
 > ##### Notes:
 > - All inputs used in devos must also be added to your flake, due to an
 >   [issue](https://github.com/NixOS/nix/pull/4641) with the `follows` attribute.
-> - Optionally, you can safely delete [lib](../../lib), [tests](../../tests) and
->   the [core profile](../../profiles/core)
 > - You can append `/community` to the `devos.url` to get access to community modules
->   which can be added in [extern](../../extern).
+>   and packages which can be added in [extern](../../extern).
+> - Many folders in devos will no longer be needed and can, optionally, be deleted.
 > - To use community profiles, you will have to copy them to your tree
 > - If you use this method, you will no longer be able to edit devos internals.

--- a/flake.nix
+++ b/flake.nix
@@ -28,68 +28,11 @@
       pkgs.inputs.nixpkgs.follows = "nixos";
     };
 
-  outputs = inputs@{ deploy, nixos, nur, self, utils, ... }:
-    let
-      inherit (self) lib;
-      inherit (lib) os;
-
-      extern = import ./extern { inherit inputs; };
-
-      multiPkgs = os.mkPkgs;
-
-      outputs = {
-        nixosConfigurations =
-          import ./hosts (nixos.lib.recursiveUpdate inputs {
-            inherit multiPkgs extern;
-            defaultSystem = "x86_64-linux";
-            lib = nixos.lib.extend (final: prev: {
-              dev = self.lib;
-            });
-          });
-
-        homeConfigurations = os.mkHomeConfigurations;
-
-        nixosModules =
-          let moduleList = import ./modules/module-list.nix;
-          in lib.pathsToImportedAttrs moduleList;
-
-        homeModules =
-          let moduleList = import ./users/modules/module-list.nix;
-          in lib.pathsToImportedAttrs moduleList;
-
-        overlay = import ./pkgs;
-        overlays = lib.pathsToImportedAttrs (lib.pathsIn ./overlays);
-
-        lib = import ./lib { inherit nixos self inputs; };
-
-        templates.flk.path = ./.;
-        templates.flk.description = "flk template";
-        defaultTemplate = self.templates.flk;
-
-        deploy.nodes = os.mkNodes deploy self.nixosConfigurations;
+    outputs = inputs@{ deploy, nixos, nur, self, utils, ... }:
+      let
+        lib = import ./lib { inherit self nixos inputs; };
+      in
+      lib.mkDevos {
+        inherit self;
       };
-
-      systemOutputs = utils.lib.eachDefaultSystem (system:
-        let pkgs = multiPkgs.${system}; in
-        {
-          checks =
-            let
-              tests = nixos.lib.optionalAttrs (system == "x86_64-linux")
-                (import ./tests { inherit self pkgs; });
-              deployHosts = nixos.lib.filterAttrs
-                (n: _: self.nixosConfigurations.${n}.config.nixpkgs.system == system) self.deploy.nodes;
-              deployChecks = deploy.lib.${system}.deployChecks { nodes = deployHosts; };
-            in
-            nixos.lib.recursiveUpdate tests deployChecks;
-
-          packages = utils.lib.flattenTreeSystem system
-            (os.mkPackages { inherit pkgs; });
-
-          devShell = import ./shell {
-            inherit self system;
-          };
-        }
-      );
-    in
-    nixos.lib.recursiveUpdate outputs systemOutputs;
 }

--- a/lib/attrs.nix
+++ b/lib/attrs.nix
@@ -21,7 +21,9 @@ rec {
       paths' = lib.filter (lib.hasSuffix ".nix") paths;
     in
     genAttrs' paths' (path: {
-      name = lib.removeSuffix ".nix" (baseNameOf path);
+      name = lib.removeSuffix ".nix"
+        # Safe as long this is just used as a name
+        (builtins.unsafeDiscardStringContext (baseNameOf path));
       value = import path;
     });
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -17,6 +17,7 @@ lib.makeExtensible (final:
     lists = callLibs ./lists.nix;
     strings = callLibs ./strings.nix;
 
+    inherit (os) mkDevos;
     inherit (attrs) mapFilterAttrs genAttrs' pathsToImportedAttrs concatAttrs;
     inherit (lists) pathsIn;
     inherit (strings) rgxToString;

--- a/lib/devos/default.nix
+++ b/lib/devos/default.nix
@@ -11,6 +11,8 @@
 
   mkNodes = dev.callLibs ./mkNodes.nix;
 
+  mkSuites = dev.callLibs ./mkSuites.nix;
+
   mkProfileAttrs = dev.callLibs ./mkProfileAttrs.nix;
 
   mkPkgs = dev.callLibs ./mkPkgs.nix;

--- a/lib/devos/default.nix
+++ b/lib/devos/default.nix
@@ -7,7 +7,12 @@
       config = { allowUnfree = true; };
     };
 
+  importIf = path: if builtins.isPath path || builtins.isString path
+    then import path else path;
+
   profileMap = map (profile: profile.default);
+
+  evalDevosArgs = dev.callLibs ./evalDevosArgs.nix;
 
   mkNodes = dev.callLibs ./mkNodes.nix;
 

--- a/lib/devos/default.nix
+++ b/lib/devos/default.nix
@@ -11,6 +11,8 @@
 
   mkNodes = dev.callLibs ./mkNodes.nix;
 
+  mkHosts = dev.callLibs ./mkHosts.nix;
+
   mkSuites = dev.callLibs ./mkSuites.nix;
 
   mkProfileAttrs = dev.callLibs ./mkProfileAttrs.nix;

--- a/lib/devos/default.nix
+++ b/lib/devos/default.nix
@@ -7,8 +7,8 @@
       config = { allowUnfree = true; };
     };
 
-  importIf = path: if builtins.isPath path || builtins.isString path
-    then import path else path;
+  importIf = path: fallback:
+    if builtins.pathExists path then import path else fallback;
 
   profileMap = map (profile: profile.default);
 

--- a/lib/devos/default.nix
+++ b/lib/devos/default.nix
@@ -14,6 +14,8 @@
 
   evalDevosArgs = dev.callLibs ./evalDevosArgs.nix;
 
+  mkDevos = dev.callLibs ./mkDevos.nix;
+
   mkNodes = dev.callLibs ./mkNodes.nix;
 
   mkHosts = dev.callLibs ./mkHosts.nix;

--- a/lib/devos/evalDevosArgs.nix
+++ b/lib/devos/evalDevosArgs.nix
@@ -26,7 +26,10 @@ let
         };
         packages = mkOption {
           # functionTo changes arg names which breaks flake check
-          type = types.anything;
+          type = types.anything // {
+            check = builtins.isFunction;
+            description = "Nixpkgs overlay";
+          };
           default = importIf "${self}/pkgs" (final: prev: {});
           defaultText = "\${self}/pkgs";
           description = ''

--- a/lib/devos/evalDevosArgs.nix
+++ b/lib/devos/evalDevosArgs.nix
@@ -1,0 +1,146 @@
+{ self, dev, nixos, inputs, ... }:
+
+{ args }:
+let
+  argOpts = with nixos.lib; { config, options, ... }:
+    let
+      inherit (dev) os;
+      inherit (os) importIf;
+
+      cfg = config;
+      inherit (cfg) self;
+
+      pathOr = x: with types; oneOf [ path x ];
+      inputAttrs = types.functionTo types.attrs;
+
+          in
+    {
+      options = with types; {
+        self = mkOption {
+          type = addCheck attrs nixos.lib.isStorePath;
+          description = "The flake to create the devos outputs for";
+        };
+        hosts = mkOption {
+          type = path;
+          default = "${self}/hosts";
+          defaultText = "\${self}/hosts";
+          description = "Path to directory containing host configurations";
+        };
+        packages = mkOption {
+          type = pathOr (functionTo inputAttrs);
+          default = "${self}/pkgs";
+          defaultText = "\${self}/pkgs";
+          apply = importIf;
+          description = ''
+            Overlay for custom packages that will be included in treewide 'pkgs'.
+            This should follow the standard nixpkgs overlay format - two argument function
+            that returns an attrset.
+          '';
+        };
+        modules = mkOption {
+          default = "${self}/modules/module-list.nix";
+          defaultText = "\${self}/modules/module-list.nix";
+          type = pathOr (listOf anything);
+          apply = x: dev.pathsToImportedAttrs (importIf x);
+          description = "list of modules to include in confgurations";
+        };
+        userModules = mkOption {
+          default = "${self}/users/modules/module-list.nix";
+          defaultText = "\${self}/users/modules/module-list.nix";
+          type = pathOr (listOf anything);
+          apply = x: dev.pathsToImportedAttrs (importIf x);
+          description = "list of modules to include in home-manager configurations";
+        };
+        profiles = mkOption {
+          type = path;
+          default = "${self}/profiles";
+          defaultText = "\${self}/profiles";
+          description = "path to profiles folder";
+        };
+        userProfiles = mkOption {
+          type = path;
+          default = "${self}/users/profiles";
+          defaultText = "\${self}/users/profiles";
+          description = "path to user profiles folder";
+        };
+        suites = mkOption {
+          type = pathOr inputAttrs;
+          default = "${self}/suites";
+          defaultText = "\${self}/suites";
+          apply = x: os.mkSuites {
+            inherit (config) profiles users userProfiles;
+            suites = importIf x;
+          };
+          description = ''
+            function with inputs 'users' and 'profiles' that returns attribute 'system'
+            which defines suites passed to configurations as the suites specialArg
+          '';
+        };
+        users = mkOption {
+          type = path;
+          default = "${self}/users";
+          defaultText = "\${self}/users";
+          description = "path to folder containing user profiles";
+        };
+        extern = mkOption {
+          type = pathOr inputAttrs;
+          default = "${self}/extern";
+          defaultText = "\${self}/extern";
+          apply = x: (importIf x) { inputs = inputs // self.inputs; };
+          description = ''
+            Function with argument 'inputs' with all devos and this flake's inputs.
+            The function should return an attribute set with modules, overlays, and
+            specialArgs to be included across devos
+          '';
+        };
+        overlays = mkOption {
+          type = path;
+          default = "${self}/overlays";
+          defaultText = "\${self}/overlays";
+          apply = x: dev.pathsToImportedAttrs (dev.pathsIn x);
+          description = "path to folder containing overlays which will be applied to pkgs";
+        };
+        overrides = mkOption {
+          type = pathOr attrs;
+          default = "${self}/overrides";
+          defaultText = "\${self}/overrides";
+          apply = importIf;
+          description = "attrset of packages and modules that will be pulled from nixpkgs master";
+        };
+        genDoc = mkOption {
+          type = functionTo attrs;
+          internal = true;
+          description = "function that returns a generated options doc derivation given nixpkgs";
+        };
+      };
+      config.genDoc =
+        let
+          singleDoc = name: value: ''
+            ## ${name}
+            ${value.description}
+
+            ${optionalString (hasAttr "type" value ) ''
+              *_Type_*:
+              ${value.type}
+            ''}
+            ${optionalString (hasAttr "default" value) ''
+              *_Default_*
+              ```
+              ${builtins.toJSON value.default or ""}
+              ```
+            ''}
+            ${optionalString (hasAttr "example" value) ''
+              *_Example_*
+              ```
+              ${value.example}
+              ```
+            ''}
+          '';
+        in
+          pkgs: with pkgs; writeText "devosOptions.md"
+            (concatStringsSep "" (mapAttrsToList singleDoc (nixosOptionsDoc { inherit options; }).optionsNix));
+    };
+in
+  nixos.lib.evalModules {
+    modules = [ argOpts args ];
+  }

--- a/lib/devos/evalDevosArgs.nix
+++ b/lib/devos/evalDevosArgs.nix
@@ -25,7 +25,8 @@ let
           description = "Path to directory containing host configurations";
         };
         packages = mkOption {
-          type = functionTo inputAttrs;
+          # functionTo changes arg names which breaks flake check
+          type = types.anything;
           default = importIf "${self}/pkgs" (final: prev: {});
           defaultText = "\${self}/pkgs";
           description = ''

--- a/lib/devos/mkDevos.nix
+++ b/lib/devos/mkDevos.nix
@@ -53,7 +53,8 @@ let
         nixos.lib.recursiveUpdate tests deployChecks;
 
       packages = utils.lib.flattenTreeSystem system
-        (os.mkPackages { inherit pkgs; });
+        (os.mkPackages { inherit pkgs; })
+        // { devosOptionsDoc = cfg.genDoc pkgs; };
 
       devShell = import "${devos}/shell" {
         inherit self pkgs system;

--- a/lib/devos/mkDevos.nix
+++ b/lib/devos/mkDevos.nix
@@ -32,9 +32,16 @@ let
 
     lib = import "${devos}/lib" { inherit self nixos inputs; };
 
+    defaultTemplate = self.templates.flk;
     templates.flk.path = builtins.toPath self;
     templates.flk.description = "flk template";
-    defaultTemplate = self.templates.flk;
+    templates.mkdevos.path =
+      let
+        excludes = [ "lib" "tests" "cachix" "nix" "theme" ".github" "bors.toml" "cachix.nix" ];
+        filter = path: type: ! builtins.elem (baseNameOf path) excludes;
+      in
+        builtins.filterSource filter ../..;
+    templates.mkdevos.description = "for mkDevos usage";
 
     deploy.nodes = os.mkNodes deploy self.nixosConfigurations;
   };

--- a/lib/devos/mkDevos.nix
+++ b/lib/devos/mkDevos.nix
@@ -3,14 +3,14 @@ let
   devos = self;
 in
 
-{ ... } @ args:
+{ self, ... } @ args:
 let
   inherit (self) lib;
   inherit (lib) os;
 
   inherit (inputs) utils deploy;
 
-  cfg = os.evalDevosArgs { inherit args; };
+  cfg = (os.evalDevosArgs { inherit args; }).config;
 
   multiPkgs = os.mkPkgs { inherit (cfg) extern overrides; };
 

--- a/lib/devos/mkDevos.nix
+++ b/lib/devos/mkDevos.nix
@@ -1,0 +1,64 @@
+{ self, nixos, inputs, ... }:
+let
+  devos = self;
+in
+
+{ ... } @ args:
+let
+  inherit (self) lib;
+  inherit (lib) os;
+
+  inherit (inputs) utils deploy;
+
+  cfg = os.evalDevosArgs { inherit args; };
+
+  multiPkgs = os.mkPkgs { inherit (cfg) extern overrides; };
+
+  outputs = {
+    nixosConfigurations = os.mkHosts {
+      inherit multiPkgs;
+      inherit (cfg) extern suites overrides;
+      dir = cfg.hosts;
+    };
+
+    homeConfigurations = os.mkHomeConfigurations;
+
+    nixosModules = cfg.modules;
+
+    homeModules = cfg.userModules;
+
+    overlay = cfg.packages;
+    inherit (cfg) overlays;
+
+    lib = import "${devos}/lib" { inherit self nixos inputs; };
+
+    templates.flk.path = builtins.toPath self;
+    templates.flk.description = "flk template";
+    defaultTemplate = self.templates.flk;
+
+    deploy.nodes = os.mkNodes deploy self.nixosConfigurations;
+  };
+
+  systemOutputs = utils.lib.eachDefaultSystem (system:
+    let pkgs = multiPkgs.${system}; in
+    {
+      checks =
+        let
+          tests = nixos.lib.optionalAttrs (system == "x86_64-linux")
+            (import "${devos}/tests" { inherit self pkgs; });
+          deployHosts = nixos.lib.filterAttrs
+            (n: _: self.nixosConfigurations.${n}.config.nixpkgs.system == system) self.deploy.nodes;
+          deployChecks = deploy.lib.${system}.deployChecks { nodes = deployHosts; };
+        in
+        nixos.lib.recursiveUpdate tests deployChecks;
+
+      packages = utils.lib.flattenTreeSystem system
+        (os.mkPackages { inherit pkgs; });
+
+      devShell = import "${devos}/shell" {
+        inherit self pkgs system;
+      };
+    });
+in
+ nixos.lib.recursiveUpdate outputs systemOutputs
+

--- a/lib/devos/mkHosts.nix
+++ b/lib/devos/mkHosts.nix
@@ -1,17 +1,8 @@
-{ extern
-, home
-, lib
-, nixos
-, override
-, multiPkgs
-, self
-, defaultSystem
-, ...
-}:
-let
-  inherit (lib) dev;
+{ lib, dev, nixos, inputs, self, ... }:
 
-  suites = import ../suites { inherit lib; };
+{ dir, extern, suites, overrides, multiPkgs, ... }:
+let
+  defaultSystem = "x86_64-linux";
 
   experimentalFeatures = [
     "flakes"
@@ -21,10 +12,9 @@ let
   ];
 
   modules = {
-    core = ../profiles/core;
+    core = ../../profiles/core;
     modOverrides = { config, overrideModulesPath, ... }:
       let
-        overrides = import ../overrides;
         inherit (overrides) modules disabledModules;
       in
       {
@@ -48,7 +38,7 @@ let
       nix.nixPath = [
         "nixpkgs=${nixos}"
         "nixos-config=${self}/compat/nixos"
-        "home-manager=${home}"
+        "home-manager=${inputs.home}"
       ];
 
       nixpkgs.pkgs = lib.mkDefault multiPkgs.${config.nixpkgs.system};
@@ -56,7 +46,7 @@ let
       nix.registry = {
         devos.flake = self;
         nixos.flake = nixos;
-        override.flake = override;
+        override.flake = inputs.override;
       };
 
       nix.extraOptions = ''
@@ -71,7 +61,7 @@ let
     # Everything in `./modules/list.nix`.
     flakeModules = { imports = builtins.attrValues self.nixosModules ++ extern.modules; };
 
-    cachix = ../cachix.nix;
+    cachix = ../../cachix.nix;
   };
 
   specialArgs = extern.specialArgs // { suites = suites.system; };
@@ -80,7 +70,7 @@ let
     let
       local = {
         require = [
-          "${toString ./.}/${hostName}.nix"
+          "${dir}/${hostName}.nix"
         ];
 
         networking = { inherit hostName; };
@@ -106,7 +96,7 @@ let
 
   hosts = dev.os.recImport
     {
-      dir = ./.;
+      inherit dir;
       _import = mkHostConfig;
     };
 in

--- a/lib/devos/mkPkgs.nix
+++ b/lib/devos/mkPkgs.nix
@@ -1,8 +1,6 @@
-{ lib, dev, nixos, self, ... }:
+{ lib, dev, nixos, self, inputs, ... }:
 
 { extern, overrides }:
-let inherit (self) inputs;
-in
 (inputs.utils.lib.eachDefaultSystem
   (system:
     let

--- a/lib/devos/mkPkgs.nix
+++ b/lib/devos/mkPkgs.nix
@@ -1,13 +1,13 @@
 { lib, dev, nixos, self, ... }:
 
+{ extern, overrides }:
 let inherit (self) inputs;
 in
 (inputs.utils.lib.eachDefaultSystem
   (system:
     let
-      extern = import ../../extern { inherit inputs; };
       overridePkgs = dev.os.pkgImport inputs.override [ ] system;
-      overridesOverlay = (import ../../overrides).packages;
+      overridesOverlay = overrides.packages;
 
       overlays = [
         (overridesOverlay overridePkgs)

--- a/lib/devos/mkProfileAttrs.nix
+++ b/lib/devos/mkProfileAttrs.nix
@@ -27,7 +27,7 @@ let mkProfileAttrs =
     f = n: _:
       lib.optionalAttrs
         (lib.pathExists "${dir}/${n}/default.nix")
-        { default = /. + "${dir}/${n}"; }
+        { default = builtins.toPath "${dir}/${n}"; }
       // mkProfileAttrs "${dir}/${n}";
   in
   lib.mapAttrs f imports;

--- a/lib/devos/mkSuites.nix
+++ b/lib/devos/mkSuites.nix
@@ -1,14 +1,8 @@
 { lib, dev, ... }:
 
-{ users, profiles, userProfiles, suites }:
+{ users, profiles, userProfiles, suites } @ args:
 let
   inherit (dev) os;
-
-  args = {
-    users = os.mkProfileAttrs (toString users);
-    profiles = os.mkProfileAttrs (toString profiles);
-    userProfiles = os.mkProfileAttrs (toString userProfiles);
-  };
 
   definedSuites = suites {
     inherit (args) users profiles userProfiles;

--- a/lib/devos/mkSuites.nix
+++ b/lib/devos/mkSuites.nix
@@ -1,0 +1,30 @@
+{ lib, dev, ... }:
+
+{ users, profiles, userProfiles, suites }:
+let
+  inherit (dev) os;
+
+  args = {
+    users = os.mkProfileAttrs (toString users);
+    profiles = os.mkProfileAttrs (toString profiles);
+    userProfiles = os.mkProfileAttrs (toString userProfiles);
+  };
+
+  definedSuites = suites {
+    inherit (args) users profiles userProfiles;
+  };
+
+  allProfiles =
+    let defaults = lib.collect (x: x ? default) profiles;
+    in map (x: x.default) defaults;
+
+  allUsers =
+    let defaults = lib.collect (x: x ? default) users;
+    in map (x: x.default) defaults;
+
+  createSuites = _: suites: lib.mapAttrs (_: v: os.profileMap v) suites // {
+    inherit allProfiles allUsers;
+  };
+
+in
+lib.mapAttrs createSuites definedSuites

--- a/shell/default.nix
+++ b/shell/default.nix
@@ -1,9 +1,8 @@
 { self ? (import ../compat).defaultNix
 , system ? builtins.currentSystem
+, pkgs ? import <nixpkgs> {}
 }:
 let
-  pkgs = (self.lib.os.mkPkgs).${system};
-
   inherit (pkgs) lib;
 
   installPkgs = (lib.nixosSystem {

--- a/suites/default.nix
+++ b/suites/default.nix
@@ -1,35 +1,10 @@
-{ lib }:
-let
-  inherit (lib) dev;
+{ users, profiles, userProfiles, ... }:
 
-  profiles = dev.os.mkProfileAttrs (toString ../profiles);
-  userProfiles = dev.os.mkProfileAttrs (toString ../users/profiles);
-  users = dev.os.mkProfileAttrs (toString ../users);
-
-  allProfiles =
-    let defaults = lib.collect (x: x ? default) profiles;
-    in map (x: x.default) defaults;
-
-  allUsers =
-    let defaults = lib.collect (x: x ? default) users;
-    in map (x: x.default) defaults;
-
-
-  suites = with profiles; rec {
+{
+  system = with profiles; rec {
     base = [ users.nixos users.root ];
   };
-
-  # available as 'suites' within the home-manager configuration
-  userSuites = with userProfiles; rec {
+  user = with userProfiles; rec {
     base = [ direnv git ];
-  };
-
-in
-{
-  system = lib.mapAttrs (_: v: dev.os.profileMap v) suites // {
-    inherit allProfiles allUsers;
-  };
-  user = lib.mapAttrs (_: v: dev.os.profileMap v) userSuites // {
-    allProfiles = userProfiles;
   };
 }


### PR DESCRIPTION
Moving all logic to lib makes things easier to change and understand, since whenever you add a feature, you only have to edit relevant functions in lib. And for a user, they don't have to understand whats happening behind the scenes. But if they want to I think reading functions in lib is simpler than reading implementation logic thats in different places around the directory.

But most importantly this allows for a lib function called `mkDevos` which is a potential solution to #91. The mkDevos function can take other an input of other flakes and build a devos flake just like this repo does. So this creates an alternate method of using devos, where you just add devos as an input then do
```
devos.lib.mkDevos { inherit self; }
```
And then you can just create the relevant directories(this could be shipped as its own template) and those directories will be imported. This change is also backwards compatible as demonstrated in the updated flake.nix where the current devos just calls `mkDevos` with itself. So a user can either just clone this repo and use it like its currently being used, or they can use the lib function.. The advantage of just using the lib function is you no longer have to worry about merging upstream and conflicts that arise, you can just update your devos input, so nix flake takes care of syncing with the mothership for you.

Keep in mind you have to add all inputs devos depends on along with devos for the new method to work because of an issue with the way `follows` works in flakes. This should be fixed by nixos/nix#4641 which would allow you to write a devos flake.nix in under 10 lines.