### PR TITLE
hosts: add cachix

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -70,6 +70,8 @@ let
 
     # Everything in `./modules/list.nix`.
     flakeModules = { imports = builtins.attrValues self.nixosModules ++ extern.modules; };
+
+    cachix = ../cachix.nix;
   };
 
   specialArgs = extern.specialArgs // { suites = suites.system; };


### PR DESCRIPTION
fixes #208 

I think it was dropped during #157. It used to be added to nixosModules, but I think its better added to hosts, I don't see a reason to export the cachix module as an output.