### PR TITLE
home-manager fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1616318638,
-        "narHash": "sha256-E6ABXtzw6bHmrIirB1sJL6S2MEa3sfcvRLzRa92frCo=",
+        "lastModified": 1616724076,
+        "narHash": "sha256-SwbPXLjN2sLy4NL/GhodiJrdkIVZwGGTGiCN3JxH1cU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ddcd476603dfd3388b1dc8234fa9d550156a51f5",
+        "rev": "fedfd430f96695997b3eaf8d7e82ca79406afa23",
         "type": "github"
       },
       "original": {

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -80,7 +80,6 @@ lib.nixosSystem (args // {
               home-manager.useUserPackages = lib.mkForce false;
               home-manager.sharedModules = [
                 {
-                  home.packages = config.environment.systemPackages;
                   home.sessionVariables = {
                     inherit (config.environment.sessionVariables) NIX_PATH;
                   };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -41,6 +41,8 @@ in
     '';
   };
 
+  homeTest = self.homeConfigurations."nixos@NixOS".home.activationPackage;
+
   libTests = pkgs.runCommandNoCC "devos-lib-tests"
     {
       buildInputs = [


### PR DESCRIPTION
- [x] integrate nix-community/home-manager#1880 (to avoid duplicate commits, we'll wait a bit to see if this gets merged)
- [x] don't use all of `systemPackages` for `flk home` 
- [x] test home-manager `activationPackage` and `flk home` as part of CI