### PR TITLE
lib/pathsIn: don't error if path doesn't exist

### DIFF
--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -4,5 +4,6 @@
     let
       fullPath = name: "${toString dir}/${name}";
     in
-    map fullPath (lib.attrNames (builtins.readDir dir));
+    map fullPath (lib.attrNames (lib.optionalAttrs
+      (builtins.pathExists dir) (builtins.readDir dir)));
 }


### PR DESCRIPTION
Really simple, just don't error if path passed to pathsIn doesn't exist. This doesn't affect much, since the majority of folders in devos end up getting referenced in some way or another outside of a pathsIn call. But it will  help for users of mkDevos, so they can safely delete folders they don't want to use. 
Can test with current overlays folder in deovs, that only gets imported through a pathsIn call.