### PR TITLE
lib/pathsToImportedAttrs: discard string context in the names to prevent flake check error

### DIFF
--- a/lib/attrs.nix
+++ b/lib/attrs.nix
@@ -21,7 +21,9 @@ rec {
       paths' = lib.filter (lib.hasSuffix ".nix") paths;
     in
     genAttrs' paths' (path: {
-      name = lib.removeSuffix ".nix" (baseNameOf path);
+      name = lib.removeSuffix ".nix"
+        # Safe as long this is just used as a name
+        (builtins.unsafeDiscardStringContext (baseNameOf path));
       value = import path;
     });
 


### PR DESCRIPTION
So I learned about this myself while working on it. Nix has a thing called string context, where strings refer to various store paths that they used to contain. This is normally a good thing to guarantee purity, but flake outputs cannot contain store paths. So when `pathsToImportedAttrs` is passed a list of store paths, and is then used for a flake output, we get a very confusing error that the string refers to a store path - even though it doesn't look like it does! 
I think its good to review this as a separate Pr, since it requires calling an unsafe nix builtin.