### PR TITLE
lib/mkPkgs: don't import external files and get inputs as argument

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,7 +89,7 @@
             (os.mkPackages { inherit pkgs; });
 
           devShell = import ./shell {
-            inherit self system;
+            inherit self system extern overrides;
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -34,8 +34,11 @@
       inherit (lib) os;
 
       extern = import ./extern { inherit inputs; };
+      overrides = import ./overrides;
 
-      multiPkgs = os.mkPkgs;
+      multiPkgs = os.mkPkgs {
+        inherit extern overrides;
+      };
 
       outputs = {
         nixosConfigurations =

--- a/lib/devos/mkPkgs.nix
+++ b/lib/devos/mkPkgs.nix
@@ -1,13 +1,11 @@
-{ lib, dev, nixos, self, ... }:
+{ lib, dev, nixos, self, inputs, ... }:
 
-let inherit (self) inputs;
-in
+{ extern, overrides }:
 (inputs.utils.lib.eachDefaultSystem
   (system:
     let
-      extern = import ../../extern { inherit inputs; };
       overridePkgs = dev.os.pkgImport inputs.override [ ] system;
-      overridesOverlay = (import ../../overrides).packages;
+      overridesOverlay = overrides.packages;
 
       overlays = [
         (overridesOverlay overridePkgs)

--- a/shell/default.nix
+++ b/shell/default.nix
@@ -1,8 +1,12 @@
 { self ? (import ../compat).defaultNix
 , system ? builtins.currentSystem
+, extern ? import ../extern { inherit (self) inputs; }
+, overrides ? import ../overrides
 }:
 let
-  pkgs = (self.lib.os.mkPkgs).${system};
+  pkgs = (self.lib.os.mkPkgs {
+    inherit overrides extern;
+  }).${system};
 
   inherit (pkgs) lib;
 


### PR DESCRIPTION
Changes mkPkgs to take extern, overrides, and pkgs as an argument. This improves their ability to be used as lib functions.