### PR TITLE
lib/mkPkgs: reorder overlays to get access to devos lib(dev)

### DIFF
--- a/lib/devos/mkPkgs.nix
+++ b/lib/devos/mkPkgs.nix
@@ -10,8 +10,6 @@ in
       overridesOverlay = (import ../../overrides).packages;
 
       overlays = [
-        (overridesOverlay overridePkgs)
-        self.overlay
         (final: prev: {
           lib = prev.lib.extend (lfinal: lprev: {
             inherit dev;
@@ -20,6 +18,8 @@ in
             utils = inputs.utils.lib;
           });
         })
+        (overridesOverlay overridePkgs)
+        self.overlay
       ]
       ++ extern.overlays
       ++ (lib.attrValues self.overlays);


### PR DESCRIPTION
nixpkgs applies overlays in the order given. This PR moves the lib extension overlay to be first so all subsequent overlays can access `dev` which is the devos lib.