### PR TITLE
Drop flattenTreeSystem and use custom function for filtering packages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -260,16 +260,15 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1608663846,
-        "narHash": "sha256-YOAXeoNLW0IubQ6AZLGuSj5kAD5n4DYXLYReLtyds1A=",
+        "lastModified": 1614513358,
+        "narHash": "sha256-LakhOx3S1dRjnh0b5Dg3mbZyH0ToC9I8Y2wKSkBaTzU=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a68df93a37cd5137ac22ffeb2d8a03acf253cc24",
+        "rev": "5466c5bbece17adaab2d82fae80b46e807611bf3",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
-        "ref": "flatten-tree-system",
         "repo": "flake-utils",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
       naersk.url = "github:nmattia/naersk";
       naersk.inputs.nixpkgs.follows = "override";
       nixos-hardware.url = "github:nixos/nixos-hardware";
-      utils.url = "github:numtide/flake-utils/flatten-tree-system";
+      utils.url = "github:numtide/flake-utils";
       pkgs.url = "path:./pkgs";
       pkgs.inputs.nixpkgs.follows = "nixos";
     };
@@ -70,7 +70,11 @@
       };
 
       systemOutputs = utils.lib.eachDefaultSystem (system:
-        let pkgs = multiPkgs.${system}; in
+        let
+          pkgs = multiPkgs.${system};
+          # all packages that are defined in ./pkgs
+          legacyPackages = os.mkPackages { inherit pkgs; };
+        in
         {
           checks =
             let
@@ -82,8 +86,8 @@
             in
             nixos.lib.recursiveUpdate tests deployChecks;
 
-          packages = utils.lib.flattenTreeSystem system
-            (os.mkPackages { inherit pkgs; });
+          inherit legacyPackages;
+          packages = lib.filterPackages system legacyPackages;
 
           devShell = import ./shell {
             inherit self system;

--- a/lib/attrs.nix
+++ b/lib/attrs.nix
@@ -26,4 +26,13 @@ rec {
     });
 
   concatAttrs = lib.fold (attr: sum: lib.recursiveUpdate sum attr) { };
+
+  # Filter out packages that support given system and follow flake check requirements
+  filterPackages = system: packages:
+    let
+      # Everything that nix flake check requires for the packages output
+      filter = (n: v: with v; let platforms = meta.hydraPlatforms or meta.platforms or [ ]; in
+        lib.isDerivation v && !meta.broken && builtins.elem system platforms);
+    in
+      lib.filterAttrs filter packages;
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -17,7 +17,8 @@ lib.makeExtensible (final:
     lists = callLibs ./lists.nix;
     strings = callLibs ./strings.nix;
 
-    inherit (attrs) mapFilterAttrs genAttrs' pathsToImportedAttrs concatAttrs;
+    inherit (attrs) mapFilterAttrs genAttrs'
+      pathsToImportedAttrs concatAttrs filterPackages;
     inherit (lists) pathsIn;
     inherit (strings) rgxToString;
   })


### PR DESCRIPTION
I don't think we should flatten the system because if a user doesn't make a package a derivation in pkgs/default.nix we should trust that there is a reason for doing so. So instead this drops the flattenTreeSystem reference(and switches to flake-utils master branch) and replaces its usage with a custom function `filterPackages`. This function filter all packages that match three conditions;
 - is a derivation
 - not broken
 - system is supported

In that order as to not cause errors when trying to reference non-derivation meta attributes.

And then also just dump *all* packages into legacy packages, so everything else is still accessible. I was considering removing the packages that are already in the packages output in legacyPackages, but I don't think its necessary since nix looks to the packages output first.