### PR TITLE
lib: only readDir if path exists with safeReadDir

### DIFF
--- a/lib/attrs.nix
+++ b/lib/attrs.nix
@@ -40,4 +40,6 @@ rec {
         lib.isDerivation v && !meta.broken && builtins.elem system platforms);
     in
       lib.filterAttrs filter packages;
+
+  safeReadDir = path: lib.optionalAttrs (builtins.pathExists path) (builtins.readDir path);
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -17,7 +17,7 @@ lib.makeExtensible (final:
     lists = callLibs ./lists.nix;
     strings = callLibs ./strings.nix;
 
-    inherit (attrs) mapFilterAttrs genAttrs'
+    inherit (attrs) mapFilterAttrs genAttrs' safeReadDir
       pathsToImportedAttrs concatAttrs filterPackages;
     inherit (lists) pathsIn;
     inherit (strings) rgxToString;

--- a/lib/devos/mkProfileAttrs.nix
+++ b/lib/devos/mkProfileAttrs.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, dev, ... }:
 
 let mkProfileAttrs =
   /**
@@ -16,7 +16,7 @@ let mkProfileAttrs =
   let
     imports =
       let
-        files = builtins.readDir dir;
+        files = dev.safeReadDir dir;
 
         p = n: v:
           v == "directory"

--- a/lib/devos/recImport.nix
+++ b/lib/devos/recImport.nix
@@ -9,4 +9,4 @@ dev.mapFilterAttrs
       let name = lib.removeSuffix ".nix" n; in lib.nameValuePair (name) (_import name)
     else
       lib.nameValuePair ("") (null))
-  (builtins.readDir dir)
+  (dev.safeReadDir dir)

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1,9 +1,8 @@
-{ lib, ... }:
+{ lib, dev, ... }:
 {
   pathsIn = dir:
     let
       fullPath = name: "${toString dir}/${name}";
     in
-    map fullPath (lib.attrNames (lib.optionalAttrs
-      (builtins.pathExists dir) (builtins.readDir dir)));
+    map fullPath (lib.attrNames (dev.safeReadDir dir));
 }

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -69,6 +69,14 @@ lib.runTests {
     (rgxToString "hat" "foohatbar" == "hat")
   ];
 
+  testSafeReadDir = {
+    expr = safeReadDir "${self}/tests/profiles" // safeReadDir "${self}/nonexistentdir";
+    expected = {
+      foo = "directory";
+      t = "directory";
+    };
+  };
+
   testSuites =
     let
       profiles = os.mkProfileAttrs (toString ./profiles);


### PR DESCRIPTION
After doing this for the second time, I realized it might be good to make a lib function for it and do it across lib.
Create a function called `safeReadDir` that only uses `builtins.readDir` if the path exists. With `optionalAttrs` any function that relies on the output won't fail since they still get an empty attrset.
Then replace all uses of `readDir` with the safe version.