### PR TITLE
Check if options exist before setting them

### DIFF
--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -94,10 +94,12 @@ lib.nixosSystem (args // {
           ];
         })).config;
     in
-    moduleList ++ [{
-      system.build = {
-        iso = isoConfig.system.build.isoImage;
-        homes = hmConfig.home-manager.users;
-      };
-    }];
+    moduleList ++ [
+      ({options, ... }: {
+        system.build = {
+          iso = isoConfig.system.build.isoImage;
+          homes = lib.optionalAttrs (options ? home-manager) hmConfig.home-manager.users;
+        };
+      })
+    ];
 })

--- a/lib/devos/mkHosts.nix
+++ b/lib/devos/mkHosts.nix
@@ -23,42 +23,54 @@ let
           modules;
       };
 
-    global = { config, pkgs, ... }: {
-      home-manager = {
-        useGlobalPkgs = true;
-        useUserPackages = true;
+    global = { config, options, pkgs, ... }:
+      with lib; lib.mkMerge [
+        (optionalAttrs (options ? home-manager) {
+          home-manager = {
+            useGlobalPkgs = true;
+            useUserPackages = true;
 
-        extraSpecialArgs = extern.userSpecialArgs // { suites = suites.user; };
-        sharedModules = extern.userModules ++ (builtins.attrValues self.homeModules);
-      };
-      users.mutableUsers = lib.mkDefault false;
-
-      hardware.enableRedistributableFirmware = lib.mkDefault true;
-
-      nix.nixPath = [
-        "nixpkgs=${nixos}"
-        "nixos-config=${self}/compat/nixos"
-        "home-manager=${inputs.home}"
+            extraSpecialArgs = extern.userSpecialArgs // { suites = suites.user; };
+            sharedModules = extern.userModules ++ (builtins.attrValues self.homeModules);
+          };
+        })
+        (optionalAttrs (options ? hardware.enableRedistributableFirmware) {
+          hardware.enableRedistributableFirmware = lib.mkDefault true;
+        })
+        (optionalAttrs (options ? users.mutableUsers) {
+          users.mutableUsers = lib.mkDefault false;
+        })
+        (optionalAttrs (options ? nix.nixPath) {
+          nix.nixPath = [
+            "nixpkgs=${nixos}"
+            "nixos-config=${self}/compat/nixos"
+            "home-manager=${inputs.home}"
+          ];
+        })
+        (optionalAttrs (options ? nix.registry) {
+          nix.registry = {
+            devos.flake = self;
+            nixos.flake = nixos;
+            override.flake = inputs.override;
+          };
+        })
+        (optionalAttrs (options ? nix.package) {
+          nix.package = pkgs.nixFlakes;
+        })
+        (optionalAttrs (options ? nix.extraOptions) {
+          nix.extraOptions = ''
+            experimental-features = ${lib.concatStringsSep " "
+              experimentalFeatures
+            }
+          '';
+        })
+        (optionalAttrs (options ? nixpkgs.pkgs) {
+          nixpkgs.pkgs = lib.mkDefault multiPkgs.${config.nixpkgs.system};
+        })
+        (optionalAttrs (options ? system.configurationRevision) {
+          system.configurationRevision = lib.mkIf (self ? rev) self.rev;
+        })
       ];
-
-      nixpkgs.pkgs = lib.mkDefault multiPkgs.${config.nixpkgs.system};
-
-      nix.registry = {
-        devos.flake = self;
-        nixos.flake = nixos;
-        override.flake = inputs.override;
-      };
-
-      nix.package = pkgs.nixFlakes;
-
-      nix.extraOptions = ''
-        experimental-features = ${lib.concatStringsSep " "
-          experimentalFeatures
-        }
-      '';
-
-      system.configurationRevision = lib.mkIf (self ? rev) self.rev;
-    };
 
     # Everything in `./modules/list.nix`.
     flakeModules = { imports = builtins.attrValues self.nixosModules ++ extern.modules; };


### PR DESCRIPTION
mkHosts is not very portable since it relies on nixos options. Which means in the future it can't be used on nix-darwin or robotnix. So here I just wrapped every option thats set to first check if it exists.

I would also like to set the precedent for future integrations added into devos to be made optional with similar methods:
 - Don't add a package unless it exists, ex: `pkgs ? deploy-rs`
 - Don't set an option unless it exists, ex: `options ? home-manager`. This one is tricky, it can't be done with `mkIf`. You have to use a combination of `mkMerge` and `optionalAttrs`, the former is usually necessary when your setting other things and the same module and you want to set an option that might not exist. See changes in devosSystem and mkHosts for examples.
 - Don't export an output that depends on a specific input, unless the input exists: ex: `inputs ? deploy`
 - Don't test relevant outputs unless they exist, ex: `self ? homeConfigurations`. Not sure what to do about this one though, most tests are tightly integrated with devos.