### PR TITLE
drop lib's self dep and pass data to each function

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,4 +1,4 @@
-args@{ nixos, self, ... }:
+args@{ nixos, ... }:
 let inherit (nixos) lib; in
 lib.makeExtensible (final:
   let callLibs = file: import file

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -1,6 +1,9 @@
-{ lib, nixos, self, inputs, ... }:
+{ lib, nixos, inputs, ... }:
 
-{ modules, ... } @ args:
+{ self, modules, ... } @ allArgs:
+let
+  args = builtins.removeAttrs allArgs [ "self" ];
+in
 lib.nixosSystem (args // {
   modules =
     let

--- a/lib/devos/mkHomeConfigurations.nix
+++ b/lib/devos/mkHomeConfigurations.nix
@@ -1,12 +1,13 @@
-{ lib, self, ... }:
+{ lib, ... }:
 
+nixosConfigurations:
 with lib;
 let
   mkHomes = host: config:
     mapAttrs' (user: v: nameValuePair "${user}@${host}" v)
       config.config.system.build.homes;
 
-  hmConfigs = mapAttrs mkHomes self.nixosConfigurations;
+  hmConfigs = mapAttrs mkHomes nixosConfigurations;
 
 in
 foldl recursiveUpdate { } (attrValues hmConfigs)

--- a/lib/devos/mkHosts.nix
+++ b/lib/devos/mkHosts.nix
@@ -1,6 +1,6 @@
-{ lib, dev, nixos, inputs, self, ... }:
+{ lib, dev, nixos, inputs, ... }:
 
-{ dir, extern, suites, overrides, multiPkgs, ... }:
+{ self, dir, extern, suites, overrides, multiPkgs, ... }:
 let
   defaultSystem = "x86_64-linux";
 
@@ -91,7 +91,7 @@ let
       };
     in
     dev.os.devosSystem {
-      inherit specialArgs;
+      inherit self specialArgs;
       system = defaultSystem;
       modules = modules // { inherit local lib; };
     };

--- a/lib/devos/mkPackages.nix
+++ b/lib/devos/mkPackages.nix
@@ -1,8 +1,8 @@
 { lib, dev, self, ... }:
 
-{ pkgs }:
+# main overlay and other overlays
+{ overlay, overlays, pkgs }:
 let
-  inherit (self) overlay overlays;
   packagesNames = lib.attrNames (overlay null null)
     ++ lib.attrNames (dev.concatAttrs
     (lib.attrValues

--- a/lib/devos/mkPkgs.nix
+++ b/lib/devos/mkPkgs.nix
@@ -1,13 +1,14 @@
-{ lib, dev, nixos, self, inputs, ... }:
+{ lib, dev, nixos, inputs, ... }:
 
-{ extern, overrides }:
+# main overlay and extra overlays
+{ overlay, overlays, extern, overrides }:
 (inputs.utils.lib.eachDefaultSystem
   (system:
     let
       overridePkgs = dev.os.pkgImport inputs.override [ ] system;
       overridesOverlay = overrides.packages;
 
-      overlays = [
+      allOverlays = [
         (final: prev: {
           lib = prev.lib.extend (lfinal: lprev: {
             inherit dev;
@@ -17,11 +18,11 @@
           });
         })
         (overridesOverlay overridePkgs)
-        self.overlay
+        overlay
       ]
       ++ extern.overlays
-      ++ (lib.attrValues self.overlays);
+      ++ (lib.attrValues overlays);
     in
-    { pkgs = dev.os.pkgImport nixos overlays system; }
+    { pkgs = dev.os.pkgImport nixos allOverlays system; }
   )
 ).pkgs

--- a/lib/mkFlake/default.nix
+++ b/lib/mkFlake/default.nix
@@ -10,7 +10,10 @@ let
 
   cfg = (evalFlakeArgs { inherit args; }).config;
 
-  multiPkgs = os.mkPkgs { inherit (cfg) extern overrides; };
+  multiPkgs = os.mkPkgs {
+    inherit (cfg) extern overrides;
+    inherit (self) overlay overlays;
+  };
 
   outputs = {
     nixosConfigurations = os.mkHosts {
@@ -19,7 +22,7 @@ let
       dir = cfg.hosts;
     };
 
-    homeConfigurations = os.mkHomeConfigurations;
+    homeConfigurations = os.mkHomeConfigurations self.nixosConfigurations;
 
     nixosModules = cfg.modules;
 
@@ -36,7 +39,10 @@ let
       pkgs = multiPkgs.${system};
       pkgs-lib = dev.pkgs-lib.${system};
       # all packages that are defined in ./pkgs
-      legacyPackages = os.mkPackages { inherit pkgs; };
+      legacyPackages = os.mkPackages {
+        inherit (self) overlay overlays;
+        inherit pkgs;
+      };
     in
     {
       checks = pkgs-lib.tests.mkChecks {


### PR DESCRIPTION
Making lib dependent on devos, was not the greatest idea since it prevents others from using the devos lib. And theres quite a few nice lib functions that people might like that they can't use right now: mkPkgs, mkPackages, mkHomeConfigurations.

This gives the specific data to each lib function that that function needs. 