### PR TITLE
make core an unecessary profile and add to suites

### DIFF
--- a/lib/devos/mkHosts.nix
+++ b/lib/devos/mkHosts.nix
@@ -12,7 +12,6 @@ let
   ];
 
   modules = {
-    core = "${self}/profiles/core";
     modOverrides = { config, overrideModulesPath, ... }:
       let
         inherit (overrides) modules disabledModules;
@@ -24,7 +23,7 @@ let
           modules;
       };
 
-    global = { config, ... }: {
+    global = { config, pkgs, ... }: {
       home-manager = {
         useGlobalPkgs = true;
         useUserPackages = true;
@@ -32,6 +31,7 @@ let
         extraSpecialArgs = extern.userSpecialArgs // { suites = suites.user; };
         sharedModules = extern.userModules ++ (builtins.attrValues self.homeModules);
       };
+      users.mutableUsers = lib.mkDefault false;
 
       hardware.enableRedistributableFirmware = lib.mkDefault true;
 
@@ -48,6 +48,8 @@ let
         nixos.flake = nixos;
         override.flake = inputs.override;
       };
+
+      nix.package = pkgs.nixFlakes;
 
       nix.extraOptions = ''
         experimental-features = ${lib.concatStringsSep " "

--- a/profiles/core/default.nix
+++ b/profiles/core/default.nix
@@ -2,7 +2,6 @@
 let inherit (lib) fileContents;
 in
 {
-  nix.package = pkgs.nixFlakes;
 
   nix.systemFeatures = [ "nixos-test" "benchmark" "big-parallel" "kvm" ];
 
@@ -144,7 +143,5 @@ in
   };
 
   services.earlyoom.enable = true;
-
-  users.mutableUsers = false;
 
 }

--- a/suites/default.nix
+++ b/suites/default.nix
@@ -2,7 +2,7 @@
 
 {
   system = with profiles; rec {
-    base = [ users.nixos users.root ];
+    base = [ core users.nixos users.root ];
   };
   user = with userProfiles; rec {
     base = [ direnv git ];


### PR DESCRIPTION
Prevents mkHosts subverting standard devos api to import core and add
all necessary core features to mkHosts, so core can be safely deleted in
suites