### PR TITLE
core: add usbutils

### DIFF
--- a/profiles/core/default.nix
+++ b/profiles/core/default.nix
@@ -28,6 +28,7 @@ in
       ripgrep
       skim
       tealdeer
+      usbutils
       utillinux
       whois
     ];


### PR DESCRIPTION
Looks like core does not include `lsusb` by default, now it does.