### PR TITLE
evalFlakeArgs: fix userSpecialArgs defaults

### DIFF
--- a/lib/mkFlake/evalArgs.nix
+++ b/lib/mkFlake/evalArgs.nix
@@ -108,7 +108,7 @@ let
           let
             defaults = {
               modules = []; overlays = []; specialArgs = {};
-              userModules = []; userSpecialArgs = [];
+              userModules = []; userSpecialArgs = {};
             };
           in
           mkOption {


### PR DESCRIPTION
Just tried to drop the line and I realized the type for the attribute was wrong.