### PR TITLE
add mkFlakeDoc to pkgs-lib to build options doc

### DIFF
--- a/doc/mkFlakeOptions.md
+++ b/doc/mkFlakeOptions.md
@@ -1,0 +1,323 @@
+## channels
+nixpkgs channels to create
+
+*_Type_*:
+attribute set of submodules
+
+*_Default_*
+```
+{"nixpkgs":{"input":"/nix/store/4dqrf3ly31g9ypgm89rn7b1p06vddll6-source"}}
+```
+
+
+## channels.<name>.config
+nixpkgs config for this channel
+
+*_Type_*:
+path that evaluates to a(n) attrs
+
+*_Default_*
+```
+{}
+```
+
+
+## channels.<name>.externalOverlays
+overlays to apply to the channel that don't get exported to the flake output
+useful to include overlays from inputs
+
+*_Type_*:
+path that evaluates to a(n) listOf
+
+*_Default_*
+```
+[]
+```
+
+
+## channels.<name>.input
+nixpkgs flake input to use for this channel
+
+*_Type_*:
+nix flake
+
+*_Default_*
+```
+"/nix/store/4dqrf3ly31g9ypgm89rn7b1p06vddll6-source"
+```
+
+
+## channels.<name>.overlays
+overlays to apply to this channel
+these will get exported under the 'overlays' flake output as <channel>/<name>
+
+*_Type_*:
+path that evaluates to a(n) listOf
+
+*_Default_*
+```
+[]
+```
+
+
+## home
+hosts, modules, suites, and profiles for home-manager
+
+*_Type_*:
+submodule
+
+*_Default_*
+```
+{}
+```
+
+
+## home.externalModules
+list of modules to include in confguration but these are not exported to the '‹name›Modules' output
+
+*_Type_*:
+path that evaluates to a(n) listOf
+
+*_Default_*
+```
+[]
+```
+
+
+## home.modules
+list of modules to include in confgurations and export in '‹name›Modules' output
+
+*_Type_*:
+path that evaluates to a(n) listOf
+
+*_Default_*
+```
+[]
+```
+
+
+## home.profiles
+path to profiles folder that can be collected into suites
+*_Type_*:
+path
+
+*_Default_*
+```
+"${self}/profiles"
+```
+
+
+## home.suites
+Function with the input of 'profiles' that returns an attribute set
+with the suites for this config system.
+These can be accessed through the 'suites' special argument.
+
+*_Type_*:
+path that evaluates to a(n) functionTo
+
+*_Default_*
+```
+"<function>"
+```
+
+
+## nixos
+hosts, modules, suites, and profiles for nixos
+
+*_Type_*:
+submodule
+
+*_Default_*
+```
+{}
+```
+
+
+## nixos.configDefaults
+defaults for all configs
+
+*_Type_*:
+submodule
+
+*_Default_*
+```
+{}
+```
+
+
+## nixos.configDefaults.channelName
+Channel this config should follow
+
+*_Type_*:
+one of <set>
+
+*_Default_*
+```
+"nixpkgs"
+```
+
+
+## nixos.configDefaults.externalmodules
+The configuration for this config
+
+*_Type_*:
+path that evaluates to a(n) anything
+
+*_Default_*
+```
+[]
+```
+
+
+## nixos.configDefaults.modules
+The configuration for this config
+
+*_Type_*:
+path that evaluates to a(n) anything
+
+*_Default_*
+```
+[]
+```
+
+
+## nixos.configDefaults.system
+system for this config
+
+*_Type_*:
+one of "aarch64-linux", "i686-linux", "x86_64-darwin", "x86_64-linux"
+
+*_Default_*
+```
+"x86_64-linux"
+```
+
+
+## nixos.configs
+configurations to include in the ‹name›Configurations output
+
+*_Type_*:
+path that evaluates to a(n) attrsOf
+
+*_Default_*
+```
+{}
+```
+
+
+## nixos.configs.<name>.channelName
+Channel this config should follow
+
+*_Type_*:
+one of <set>
+
+*_Default_*
+```
+"nixpkgs"
+```
+
+
+## nixos.configs.<name>.externalmodules
+The configuration for this config
+
+*_Type_*:
+path that evaluates to a(n) anything
+
+*_Default_*
+```
+[]
+```
+
+
+## nixos.configs.<name>.modules
+The configuration for this config
+
+*_Type_*:
+path that evaluates to a(n) anything
+
+*_Default_*
+```
+[]
+```
+
+
+## nixos.configs.<name>.system
+system for this config
+
+*_Type_*:
+one of "aarch64-linux", "i686-linux", "x86_64-darwin", "x86_64-linux"
+
+*_Default_*
+```
+"x86_64-linux"
+```
+
+
+## nixos.externalModules
+list of modules to include in confguration but these are not exported to the '‹name›Modules' output
+
+*_Type_*:
+path that evaluates to a(n) listOf
+
+*_Default_*
+```
+[]
+```
+
+
+## nixos.modules
+list of modules to include in confgurations and export in '‹name›Modules' output
+
+*_Type_*:
+path that evaluates to a(n) listOf
+
+*_Default_*
+```
+[]
+```
+
+
+## nixos.profiles
+path to profiles folder that can be collected into suites
+*_Type_*:
+path
+
+*_Default_*
+```
+"${self}/profiles"
+```
+
+
+## nixos.suites
+Function with the input of 'profiles' that returns an attribute set
+with the suites for this config system.
+These can be accessed through the 'suites' special argument.
+
+*_Type_*:
+path that evaluates to a(n) functionTo
+
+*_Default_*
+```
+"<function>"
+```
+
+
+## self
+The flake to create the devos outputs for
+*_Type_*:
+nix flake
+
+
+
+## supportedSystems
+The systems supported by this flake
+
+*_Type_*:
+list of strings
+
+*_Default_*
+```
+["aarch64-linux","i686-linux","x86_64-darwin","x86_64-linux"]
+```
+
+

--- a/lib/pkgs-lib/default.nix
+++ b/lib/pkgs-lib/default.nix
@@ -15,6 +15,7 @@ lib.genAttrs utils.lib.defaultSystems (system:
 
       tests = callLibs ./tests;
       shell = callLibs ./shell;
+      mkFlakeDoc = callLibs ./mkFlakeDoc.nix;
     }
   )
 )

--- a/lib/pkgs-lib/mkFlakeDoc.nix
+++ b/lib/pkgs-lib/mkFlakeDoc.nix
@@ -1,0 +1,31 @@
+{ dev, pkgs, lib, ... }:
+let
+  singleDoc = name: value: ''
+    ## ${name}
+    ${value.description}
+    ${lib.optionalString (value ? type) ''
+      *_Type_*:
+      ${value.type}
+    ''}
+    ${lib.optionalString (value ? default) ''
+      *_Default_*
+      ```
+      ${builtins.toJSON value.default}
+      ```
+    ''}
+    ${lib.optionalString (value ? example) ''
+      *_Example_*
+      ```
+      ${value.example}
+      ```
+    ''}
+  '';
+
+  options = (dev.mkFlake.evalNewArgs { args = { }; }).options;
+
+  processedOptions = (pkgs.nixosOptionsDoc { inherit options; }).optionsNix;
+
+  fullDoc = lib.concatStringsSep "" (lib.mapAttrsToList singleDoc processedOptions);
+in
+pkgs.writeText "devosOptions.md" fullDoc
+


### PR DESCRIPTION
Just built the doc - requires a bit of fen-angling - because current api-next flake doesn't work since mkflake hasn't been updated. We can use this PR to go over option/type descriptions and include any doc improvements. 

Overall I think the descriptions can use some work, we need to clearly communicate what each API argument is for and the reasoning behind the option. I think a fresh set of eyes could help with that, especially someone who wasn't part of all the discussion for the API design.

This document should be able to quickly answer questions like "What happened to extern?" or "How should I import modules from other flakes?". 

I should not attempt to cover everything - thats what the other doc sections are for - just a simple and straightforward summary of what each argument provides and is used for.

This replaces parts of #232.