### PR TITLE
ref: reduce exposure to callLibs

### DIFF
--- a/lib/attrs.nix
+++ b/lib/attrs.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib }:
 rec {
   # mapFilterAttrs ::
   #   (name -> value -> bool )

--- a/lib/devos/default.nix
+++ b/lib/devos/default.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib }:
 {
   # pkgImport :: Nixpkgs -> Overlays -> System -> Pkgs
   pkgImport = nixpkgs: overlays: system:

--- a/lib/devos/default.nix
+++ b/lib/devos/default.nix
@@ -1,4 +1,4 @@
-{ lib }:
+{ lib, utils }:
 {
   # pkgImport :: Nixpkgs -> Overlays -> System -> Pkgs
   pkgImport = nixpkgs: overlays: system:
@@ -9,22 +9,22 @@
 
   profileMap = map (profile: profile.default);
 
-  mkNodes = lib.callLibs ./mkNodes.nix;
+  mkNodes =  import ./mkNodes.nix { inherit lib; };
 
-  mkHosts = lib.callLibs ./mkHosts.nix;
+  mkHosts = import ./mkHosts.nix { inherit lib; };
 
-  mkSuites = lib.callLibs ./mkSuites.nix;
+  mkSuites = import ./mkSuites.nix { inherit lib; };
 
-  mkProfileAttrs = lib.callLibs ./mkProfileAttrs.nix;
+  mkProfileAttrs = import ./mkProfileAttrs.nix { inherit lib; };
 
-  mkPkgs = lib.callLibs ./mkPkgs.nix;
+  mkPkgs = import ./mkPkgs.nix { inherit lib utils; };
 
-  recImport = lib.callLibs ./recImport.nix;
+  recImport = import ./recImport.nix { inherit lib; };
 
-  devosSystem = lib.callLibs ./devosSystem.nix;
+  devosSystem = import ./devosSystem.nix { inherit lib; };
 
-  mkHomeConfigurations = lib.callLibs ./mkHomeConfigurations.nix;
+  mkHomeConfigurations = import ./mkHomeConfigurations.nix { inherit lib; };
 
-  mkPackages = lib.callLibs ./mkPackages.nix;
+  mkPackages = import ./mkPackages.nix { inherit lib; };
 }
 

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -1,4 +1,6 @@
-{ lib, nixpkgs, userFlakeSelf, userFlakeInputs, ... }:
+{ lib }:
+
+{ userFlakeNixos, userFlakeSelf, userFlakeInputs }:
 
 { modules, ... } @ args:
 lib.nixosSystem (args // {
@@ -13,7 +15,7 @@ lib.nixosSystem (args // {
         (args // {
           modules = moduleList ++ [
 
-            "${nixpkgs}/${modpath}/installer/cd-dvd/installation-cd-minimal-new-kernel.nix"
+            "${userFlakeNixos}/${modpath}/installer/cd-dvd/installation-cd-minimal-new-kernel.nix"
 
             ({ config, suites, ... }: {
 

--- a/lib/devos/mkHomeConfigurations.nix
+++ b/lib/devos/mkHomeConfigurations.nix
@@ -1,4 +1,6 @@
-{ lib, userFlakeSelf, ... }:
+{ lib }:
+
+{ userFlakeSelf }:
 
 with lib;
 let

--- a/lib/devos/mkHosts.nix
+++ b/lib/devos/mkHosts.nix
@@ -1,6 +1,8 @@
 { lib  }:
 
-{ dir, extern, suites, overrides, multiPkgs, userFlakeNixOS, userFlakeInputs, userFlakeSelf }:
+{ userFlakeNixOS, userFlakeInputs, userFlakeSelf }:
+
+{ dir, extern, suites, overrides, multiPkgs }:
 let
   defaultSystem = "x86_64-linux";
 
@@ -91,6 +93,8 @@ let
       };
     in
     lib.os.devosSystem {
+      inherit userFlakeNixOS userFlakeInputs userFlakeSelf;
+    } {
       inherit specialArgs;
       system = defaultSystem;
       modules = modules // { inherit local lib; };

--- a/lib/devos/mkHosts.nix
+++ b/lib/devos/mkHosts.nix
@@ -1,6 +1,6 @@
-{ lib, nixpkgs, userFlakeInputs, userFlakeSelf, ... }:
+{ lib  }:
 
-{ dir, extern, suites, overrides, multiPkgs, ... }:
+{ dir, extern, suites, overrides, multiPkgs, userFlakeNixOS, userFlakeInputs, userFlakeSelf }:
 let
   defaultSystem = "x86_64-linux";
 
@@ -36,7 +36,7 @@ let
       hardware.enableRedistributableFirmware = lib.mkDefault true;
 
       nix.nixPath = [
-        "nixpkgs=${nixpkgs}"
+        "nixpkgs=${userFlakeNixOS}"
         "nixos-config=${userFlakeSelf}/compat/nixos"
         "home-manager=${userFlakeInputs.home}"
       ];
@@ -45,7 +45,7 @@ let
 
       nix.registry = {
         devos.flake = userFlakeSelf;
-        nixos.flake = nixpkgs;
+        nixos.flake = userFlakeNixOS;
         override.flake = userFlakeInputs.override;
       };
 

--- a/lib/devos/mkNodes.nix
+++ b/lib/devos/mkNodes.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib }:
 
 /**
   Synopsis: mkNodes _nixosConfigurations_

--- a/lib/devos/mkPackages.nix
+++ b/lib/devos/mkPackages.nix
@@ -1,4 +1,6 @@
-{ lib, userFlakeSelf, ... }:
+{ lib }:
+
+{ userFlakeSelf }:
 
 { pkgs }:
 let

--- a/lib/devos/mkPkgs.nix
+++ b/lib/devos/mkPkgs.nix
@@ -1,6 +1,8 @@
 { lib, utils }:
 
-{ extern, overrides, userFlakeNixOS, userFlakeSelf, userFlakeInputs }:
+{ userFlakeNixOS, userFlakeSelf, userFlakeInputs }:
+
+{ extern, overrides }:
 (utils.lib.eachDefaultSystem
   (system:
     let

--- a/lib/devos/mkPkgs.nix
+++ b/lib/devos/mkPkgs.nix
@@ -1,6 +1,6 @@
-{ lib, nixpkgs, userFlakeSelf, utils, userFlakeInputs, ... }:
+{ lib, utils }:
 
-{ extern, overrides }:
+{ extern, overrides, userFlakeNixOS, userFlakeSelf, userFlakeInputs }:
 (utils.lib.eachDefaultSystem
   (system:
     let
@@ -20,6 +20,6 @@
       ++ extern.overlays
       ++ (lib.attrValues userFlakeSelf.overlays);
     in
-    { pkgs = lib.os.pkgImport nixpkgs overlays system; }
+    { pkgs = lib.os.pkgImport userFlakeNixOS overlays system; }
   )
 ).pkgs

--- a/lib/devos/mkProfileAttrs.nix
+++ b/lib/devos/mkProfileAttrs.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib }:
 
 let mkProfileAttrs =
   /**

--- a/lib/devos/mkSuites.nix
+++ b/lib/devos/mkSuites.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib }:
 
 { users, profiles, userProfiles, suites } @ args:
 let

--- a/lib/devos/recImport.nix
+++ b/lib/devos/recImport.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib }:
 
 { dir, _import ? base: import "${dir}/${base}.nix" }:
 lib.mapFilterAttrs

--- a/lib/flake.nix
+++ b/lib/flake.nix
@@ -21,14 +21,17 @@
       let callLibs = file: import file
         ({
           lib = final;
-          userFlakeInputs = {}; # TODO: Erm, this must become a proper argument to mkFlake
+          userFlakeNixos = {};
+          userFlakeSelf = {};
+          userFlakeInputs = {}; # TODO: Erm, theese must become proper arguments to mkFlake
         } // inputs);
       in
       with final;
       let
-        attrs = callLibs ./attrs.nix;
-        lists = callLibs ./lists.nix;
-        strings = callLibs ./strings.nix;
+
+        attrs = import ./attrs.nix { lib = prev; };
+        lists = import ./lists.nix { lib = prev; };
+        strings = import ./strings.nix { lib = prev; };
       in
 
       utils.lib
@@ -38,7 +41,7 @@
       {
         inherit callLibs;
 
-        os = callLibs ./devos;
+        os = import ./devos { lib = final; };
 
         mkFlake = {
           __functor = callLibs ./mkFlake;
@@ -46,7 +49,10 @@
           evalOldArgs = callLibs ./mkFlake/evalOldArgs.nix;
         };
 
-        pkgs-lib = callLibs ./pkgs-lib;
+        pkgs-lib = import ./pkgs-lib {
+          lib = final;
+          inherit nixpkgs deploy devshell;
+        };
 
         inherit (attrs) mapFilterAttrs genAttrs' safeReadDir
           pathsToImportedAttrs concatAttrs filterPackages;

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib }:
 {
   pathsIn = dir:
     let

--- a/lib/pkgs-lib/default.nix
+++ b/lib/pkgs-lib/default.nix
@@ -1,4 +1,4 @@
-args@{ lib, nixpkgs, ... }:
+args@{ lib, nixpkgs, deploy, devshell }:
 lib.genAttrs lib.defaultSystems (system:
   lib.makeExtensible (final:
     let

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib }:
 {
   # returns matching part of _regex_ _string_; null indicates failure.
   rgxToString = regex: string:


### PR DESCRIPTION
for clarity's sake, expose which function uses final and prev, so that
people can have a clearer understanding how they relate to each other
in terms of dependencies.

also a simple `{ lib = final; }` probably does not warrant a complete
callLibs obscurization.