### PR TITLE
lib: one line for arguments, drop userFlake*

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,7 +81,7 @@
         "utils": "utils_2"
       },
       "locked": {
-        "narHash": "sha256-aGpcPxOBIPnwj6uLNtpKefZjEbDkZnMHZ2mH12veHnY=",
+        "narHash": "sha256-LvO5VwFNFzb2xbmgw+fWhkrRY1KMlp5vxqQU/BqS0H8=",
         "path": "./lib",
         "type": "path"
       },
@@ -280,7 +280,7 @@
         ]
       },
       "locked": {
-        "narHash": "sha256-XG4TOZObj2Wd8KiqnHgtlWjjMbJOIJB7+DxUFzMCXw8=",
+        "narHash": "sha256-Zs7dc0dNNa0Z3//+Gckxj7SKrMqVovY0xZZ1z8xWnEg=",
         "path": "./pkgs",
         "type": "path"
       },
@@ -337,11 +337,11 @@
     },
     "utils_2": {
       "locked": {
-        "lastModified": 1618217525,
-        "narHash": "sha256-WGrhVczjXTiswQaoxQ+0PTfbLNeOQM6M36zvLn78AYg=",
+        "lastModified": 1618868421,
+        "narHash": "sha256-vyoJhLV6cJ8/tWz+l9HZLIkb9Rd9esE7p+0RL6zDR6Y=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c6169a2772643c4a93a0b5ac1c61e296cba68544",
+        "rev": "eed214942bcfb3a8cc09eb3b28ca7d7221e44a94",
         "type": "github"
       },
       "original": {

--- a/lib/devos/default.nix
+++ b/lib/devos/default.nix
@@ -9,7 +9,7 @@
 
   profileMap = list: map (profile: profile.default) (lib.flatten list);
 
-  mkNodes =  import ./mkNodes.nix { inherit lib; };
+  mkNodes = import ./mkNodes.nix { inherit lib; };
 
   mkHosts = import ./mkHosts.nix { inherit lib; };
 

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -1,8 +1,7 @@
 { lib }:
 
-{ userFlakeNixOS, userFlakeSelf, userFlakeInputs }:
-
-{ modules, ... } @ args:
+{ self, nixos, inputs, modules, ... } @ allArgs:
+let args = builtins.removeAttrs allArgs [ "self" "nixos" "inputs" ]; in
 lib.nixosSystem (args // {
   modules =
     let
@@ -15,7 +14,7 @@ lib.nixosSystem (args // {
         (args // {
           modules = moduleList ++ [
 
-            "${userFlakeNixOS}/${modpath}/installer/cd-dvd/installation-cd-minimal-new-kernel.nix"
+            "${nixos}/${modpath}/installer/cd-dvd/installation-cd-minimal-new-kernel.nix"
 
             ({ config, suites, ... }: {
 
@@ -25,15 +24,15 @@ lib.nixosSystem (args // {
               disabledModules = map (x: [ x ])
                 (lib.remove modules.core suites.allProfiles);
 
-              nix.registry = lib.mapAttrs (n: v: { flake = v; }) userFlakeInputs;
+              nix.registry = lib.mapAttrs (n: v: { flake = v; }) inputs;
 
               isoImage.isoBaseName = "nixos-" + config.networking.hostName;
               isoImage.contents = [{
-                source = userFlakeSelf;
+                source = self;
                 target = "/devos/";
               }];
               isoImage.storeContents = [
-                userFlakeSelf.devShell.${config.nixpkgs.system}
+                self.devShell.${config.nixpkgs.system}
                 # include also closures that are "switched off" by the
                 # above profile filter on the local config attribute
                 fullHostConfig.system.build.toplevel

--- a/lib/devos/mkHomeConfigurations.nix
+++ b/lib/devos/mkHomeConfigurations.nix
@@ -1,6 +1,6 @@
 { lib }:
 
-{ userFlakeSelf }:
+nixosConfigurations:
 
 with lib;
 let
@@ -8,7 +8,7 @@ let
     mapAttrs' (user: v: nameValuePair "${user}@${host}" v.home)
       config.config.system.build.homes;
 
-  hmConfigs = mapAttrs mkHomes userFlakeSelf.nixosConfigurations;
+  hmConfigs = mapAttrs mkHomes nixosConfigurations;
 
 in
 foldl recursiveUpdate { } (attrValues hmConfigs)

--- a/lib/devos/mkPackages.nix
+++ b/lib/devos/mkPackages.nix
@@ -1,10 +1,7 @@
 { lib }:
 
-{ userFlakeSelf }:
-
-{ pkgs }:
+{ overlay, overlays, pkgs }:
 let
-  inherit (userFlakeSelf) overlay overlays;
   packagesNames = lib.attrNames (overlay null null)
     ++ lib.attrNames (lib.concatAttrs
     (lib.attrValues

--- a/lib/devos/mkPkgs.nix
+++ b/lib/devos/mkPkgs.nix
@@ -1,12 +1,10 @@
 { lib, utils }:
 
-{ userFlakeNixOS, userFlakeSelf, userFlakeInputs }:
-
-{ extern, overrides }:
+{ self, nixos, inputs, extern, overrides }:
 (utils.lib.eachDefaultSystem
   (system:
     let
-      overridePkgs = lib.os.pkgImport userFlakeInputs.override [ ] system;
+      overridePkgs = lib.os.pkgImport inputs.override [ ] system;
       overridesOverlay = overrides.packages;
 
       overlays = [
@@ -17,11 +15,11 @@
           });
         })
         (overridesOverlay overridePkgs)
-        userFlakeSelf.overlay
+        self.overlay
       ]
       ++ extern.overlays
-      ++ (lib.attrValues userFlakeSelf.overlays);
+      ++ (lib.attrValues self.overlays);
     in
-    { pkgs = lib.os.pkgImport userFlakeNixOS overlays system; }
+    { pkgs = lib.os.pkgImport nixos overlays system; }
   )
 ).pkgs

--- a/lib/devos/mkProfileAttrs.nix
+++ b/lib/devos/mkProfileAttrs.nix
@@ -2,16 +2,16 @@
 
 let mkProfileAttrs =
   /**
-  Synopsis: mkProfileAttrs _path_
+    Synopsis: mkProfileAttrs _path_
 
-  Recursively collect the subdirs of _path_ containing a default.nix into attrs.
-  This sets a contract, eliminating ambiguity for _default.nix_ living under the
-  profile directory.
+    Recursively collect the subdirs of _path_ containing a default.nix into attrs.
+    This sets a contract, eliminating ambiguity for _default.nix_ living under the
+    profile directory.
 
-  Example:
-  let profiles = mkProfileAttrs ./profiles; in
-  assert profiles ? core.default; 0
-  **/
+    Example:
+    let profiles = mkProfileAttrs ./profiles; in
+    assert profiles ? core.default; 0
+    **/
   dir:
   let
     imports =

--- a/lib/flake.lock
+++ b/lib/flake.lock
@@ -1,0 +1,147 @@
+{
+  "nodes": {
+    "deploy": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1616406726,
+        "narHash": "sha256-n9zmgxR03QNrvs9/fHewqE0j3SjL7Y+cglBCFu3U3rg=",
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "rev": "9e405fbc5ab5bacbd271fd78c6b6b6877c4d9f8d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "type": "github"
+      }
+    },
+    "devshell": {
+      "locked": {
+        "lastModified": 1618523768,
+        "narHash": "sha256-Gev9da35pHUey3kGz/zrJFc/9ICs++vPCho7qB1mqd8=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "709fe4d04a9101c9d224ad83f73416dce71baf21",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1606424373,
+        "narHash": "sha256-oq8d4//CJOrVj+EcOaSXvMebvuTkmBJuT5tzlfewUnQ=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "99f1c2157fba4bfe6211a321fd0ee43199025dbf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1610392286,
+        "narHash": "sha256-3wFl5y+4YZO4SgRYK8WE7JIS3p0sxbgrGaQ6RMw+d98=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "d7bfbad3304fd768c0f93a4c3b50976275e6d4be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "ref": "master",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1610942247,
+        "narHash": "sha256-PKo1ATAlC6BmfYSRmX0TVmNoFbrec+A5OKcabGEu2yU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7d71001b796340b219d1bfa8552c81995017544a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1619244632,
+        "narHash": "sha256-IDcbMRnyKO9WlQ5xzIlM3HfWAUKTy+3xSd+CvDGiLgE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5cecebfb2f76da7b93f19967e99b3ff4fb4d2850",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "deploy": "deploy",
+        "devshell": "devshell",
+        "nixpkgs": "nixpkgs_2",
+        "utils": "utils_2"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1610051610,
+        "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3982c9903e93927c2164caa727cd3f6a0e6d14cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_2": {
+      "locked": {
+        "lastModified": 1618868421,
+        "narHash": "sha256-vyoJhLV6cJ8/tWz+l9HZLIkb9Rd9esE7p+0RL6zDR6Y=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "eed214942bcfb3a8cc09eb3b28ca7d7221e44a94",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lib/flake.nix
+++ b/lib/flake.nix
@@ -4,87 +4,84 @@
   inputs =
     {
       deploy.url = "github:serokell/deploy-rs";
-      deploy.inputs = {
-        utils.follows = "utils";
-      };
       devshell.url = "github:numtide/devshell";
       utils.url = "github:numtide/flake-utils";
-      
     };
 
-  outputs = inputs@{ self, nixpkgs, deploy, devshell, utils, ... }: let
-
-    lib = nixpkgs.lib.makeExtensible (self:
-      let
-        attrs = import ./attrs.nix { lib = nixpkgs.lib // self; };
-        lists = import ./lists.nix { lib = nixpkgs.lib // self; };
-        strings = import ./strings.nix { lib = nixpkgs.lib // self; };
-      in
-
-      utils.lib
-
-      //
-
-      {
-        os = import ./devos {
-          lib = nixpkgs.lib // self;
-          inherit utils;
-        };
-
-        mkFlake = {
-          __functor = import ./mkFlake {
-            lib = nixpkgs.lib // self;
-            inherit deploy;
-          };
-          evalArgs = import  ./mkFlake/evalArgs.nix { lib = nixpkgs.lib // self; };
-          evalOldArgs = import  ./mkFlake/evalOldArgs.nix { lib = nixpkgs.lib // self; };
-        };
-
-        pkgs-lib = import ./pkgs-lib {
-          lib = nixpkgs.lib // self;
-          inherit nixpkgs deploy devshell;
-        };
-
-        inherit (attrs)
-          mapFilterAttrs
-          genAttrs'
-          safeReadDir
-          pathsToImportedAttrs
-          concatAttrs
-          filterPackages;
-        inherit (lists) pathsIn;
-        inherit (strings) rgxToString;
-      }
-    );
-
-    jobs = import ./jobs { inherit nixpkgs; lib = nixpkgs.lib // lib; };
-
-  in
-
-  {
-    inherit jobs;
-
-    lib = utils.lib // {
-      inherit (lib)
-        mkFlake;
-    };
-
-  }
-
-  //
-
-  utils.lib.eachDefaultSystem (system:
+  outputs = inputs@{ self, nixpkgs, deploy, devshell, utils, ... }:
     let
-      nixpkgs' = import nixpkgs { inherit system; overlays = []; config = {}; };
+
+      lib = nixpkgs.lib.makeExtensible (self:
+        let
+          attrs = import ./attrs.nix { lib = nixpkgs.lib // self; };
+          lists = import ./lists.nix { lib = nixpkgs.lib // self; };
+          strings = import ./strings.nix { lib = nixpkgs.lib // self; };
+        in
+
+        utils.lib
+
+        //
+
+        {
+          os = import ./devos {
+            lib = nixpkgs.lib // self;
+            inherit utils;
+          };
+
+          mkFlake = {
+            __functor = import ./mkFlake {
+              lib = nixpkgs.lib // self;
+              inherit deploy;
+            };
+            evalArgs = import ./mkFlake/evalArgs.nix { lib = nixpkgs.lib // self; };
+            evalOldArgs = import ./mkFlake/evalOldArgs.nix { lib = nixpkgs.lib // self; };
+          };
+
+          pkgs-lib = import ./pkgs-lib {
+            lib = nixpkgs.lib // self;
+            inherit nixpkgs deploy devshell;
+          };
+
+          inherit (attrs)
+            mapFilterAttrs
+            genAttrs'
+            safeReadDir
+            pathsToImportedAttrs
+            concatAttrs
+            filterPackages;
+          inherit (lists) pathsIn;
+          inherit (strings) rgxToString;
+        }
+      );
+
+      jobs = import ./jobs { inherit nixpkgs; lib = nixpkgs.lib // lib; };
+
     in
+
+    {
+      inherit jobs;
+
+      lib = utils.lib // {
+        inherit (lib)
+          mkFlake;
+      };
+
+    }
+
+    //
+
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
       {
         checks = {
           tests = import ./tests {
-            inherit (nixpkgs') pkgs;
+            inherit pkgs;
             lib = nixpkgs.lib // lib;
           };
         };
       }
-  );
+    );
 
 }

--- a/lib/jobs/default.nix
+++ b/lib/jobs/default.nix
@@ -1,5 +1,7 @@
-{ nixpkgs, lib, system ? "x86_64-linux" }: let
-  pkgs = import nixpkgs { inherit system; overlays = []; config = {}; };
-in {
+{ nixpkgs, lib, system ? "x86_64-linux" }:
+let
+  pkgs = import nixpkgs { inherit system; overlays = [ ]; config = { }; };
+in
+{
   mkFlakeDoc = import ./mkFlakeDoc.nix { inherit pkgs lib; };
 }

--- a/lib/jobs/mkFlakeDoc.nix
+++ b/lib/jobs/mkFlakeDoc.nix
@@ -22,9 +22,7 @@ let
   '';
 
   options = (
-    lib.mkFlake.evalArgs
-      { userFlakeSelf = {}; userFlakeNixOS = {}; }
-      { args = { }; }
+    lib.mkFlake.evalArgs { nixos = "nixos"; args = { }; }
   ).options;
 
   processedOptions = (pkgs.nixosOptionsDoc { inherit options; }).optionsNix;

--- a/lib/mkFlake/default.nix
+++ b/lib/mkFlake/default.nix
@@ -6,31 +6,26 @@ in
 _: { self, inputs, nixos, ... } @ args:
 let
 
-  userFlakeSelf = self;
-  userFlakeInputs = inputs;
-  userFlakeNixOS = nixos;
-
   cfg = (
     lib.mkFlake.evalOldArgs
-      { inherit userFlakeSelf userFlakeInputs; }
-      { inherit args; }
+      { inherit self inputs args; }
   ).config;
 
   multiPkgs = os.mkPkgs
-    { inherit userFlakeSelf userFlakeInputs userFlakeNixOS; }
-    { inherit (cfg) extern overrides; };
+    {
+      inherit self inputs nixos;
+      inherit (cfg) extern overrides;
+    };
 
   outputs = {
     nixosConfigurations = os.mkHosts
-      { inherit userFlakeSelf userFlakeInputs userFlakeNixOS; }
       {
-        inherit multiPkgs;
+        inherit self inputs nixos multiPkgs;
         inherit (cfg) extern suites overrides;
         dir = cfg.hosts;
       };
 
-    homeConfigurations = os.mkHomeConfigurations
-      { inherit userFlakeSelf; };
+    homeConfigurations = os.mkHomeConfigurations self.nixosConfigurations;
 
     nixosModules = cfg.modules;
 
@@ -39,7 +34,7 @@ let
     overlay = cfg.packages;
     inherit (cfg) overlays;
 
-    deploy.nodes = os.mkNodes deploy userFlakeSelf.nixosConfigurations;
+    deploy.nodes = os.mkNodes deploy self.nixosConfigurations;
   };
 
   systemOutputs = lib.eachDefaultSystem (system:
@@ -47,15 +42,16 @@ let
       pkgs = multiPkgs.${system};
       pkgs-lib = lib.pkgs-lib.${system};
       # all packages that are defined in ./pkgs
-      legacyPackages = os.mkPackages
-        { inherit userFlakeSelf; }
-        { inherit pkgs; };
+      legacyPackages = os.mkPackages {
+        inherit pkgs;
+        inherit (self) overlay overlays;
+      };
     in
     {
       checks = pkgs-lib.tests.mkChecks {
-        inherit (userFlakeSelf.deploy) nodes;
-        hosts = userFlakeSelf.nixosConfigurations;
-        homes = userFlakeSelf.homeConfigurations;
+        inherit (self.deploy) nodes;
+        hosts = self.nixosConfigurations;
+        homes = self.homeConfigurations;
       };
 
       inherit legacyPackages;

--- a/lib/mkFlake/evalArgs.nix
+++ b/lib/mkFlake/evalArgs.nix
@@ -1,8 +1,6 @@
 { lib }:
 
-{ userFlakeSelf, userFlakeNixOS }:
-
-{ args }:
+{ nixos, args }:
 let
   argOpts = with lib; { config, ... }:
     let
@@ -51,10 +49,10 @@ let
         options = with types; {
           input = mkOption {
             type = flakeType;
-            default = userFlakeNixOS;
+            default = nixos;
             description = ''
               nixpkgs flake input to use for this channel
-           '';
+            '';
           };
           overlays = mkOption {
             type = pathToListOf overlayType;
@@ -198,7 +196,7 @@ let
           let
             default = {
               nixpkgs = {
-                input = userFlakeNixOS;
+                input = nixos;
               };
             };
           in

--- a/lib/mkFlake/evalOldArgs.nix
+++ b/lib/mkFlake/evalOldArgs.nix
@@ -1,8 +1,6 @@
 { lib }:
 
-{ userFlakeSelf, userFlakeInputs }:
-
-{ args }:
+{ self, inputs, args }:
 let
   argOpts = with lib; { config, options, ... }:
     let
@@ -32,8 +30,8 @@ let
         };
         hosts = mkOption {
           type = path;
-          default = "${userFlakeSelf}/hosts";
-          defaultText = "\${userFlakeSelf}/hosts";
+          default = "${self}/hosts";
+          defaultText = "\${self}/hosts";
           apply = toString;
           description = ''
             Path to directory containing host configurations that will be exported
@@ -74,15 +72,15 @@ let
         };
         profiles = mkOption {
           type = path;
-          default = "${userFlakeSelf}/profiles";
-          defaultText = "\${userFlakeSelf}/profiles";
+          default = "${self}/profiles";
+          defaultText = "\${self}/profiles";
           apply = x: os.mkProfileAttrs (toString x);
           description = "path to profiles folder that can be collected into suites";
         };
         userProfiles = mkOption {
           type = path;
-          default = "${userFlakeSelf}/users/profiles";
-          defaultText = "\${userFlakeSelf}/users/profiles";
+          default = "${self}/users/profiles";
+          defaultText = "\${self}/users/profiles";
           apply = x: os.mkProfileAttrs (toString x);
           description = "path to user profiles folder that can be collected into userSuites";
         };
@@ -107,8 +105,8 @@ let
           };
         users = mkOption {
           type = path;
-          default = "${userFlakeSelf}/users";
-          defaultText = "\${userFlakeSelf}/users";
+          default = "${self}/users";
+          defaultText = "\${self}/users";
           apply = x: os.mkProfileAttrs (toString x);
           description = ''
             path to folder containing profiles that define system users
@@ -131,9 +129,9 @@ let
               { modules = []; overlays = []; specialArgs = []; userModules = []; userSpecialArgs = []; }
             '';
             # So unneeded extern attributes can safely be deleted
-            apply = x: defaults // (x { inputs = userFlakeInputs // userFlakeSelf.inputs; });
+            apply = x: defaults // (x { inputs = inputs // self.inputs; });
             description = ''
-              Function with argument 'inputs' that contains all devos and ''${userFlakeSelf}'s inputs.
+              Function with argument 'inputs' that contains all devos and ''${self}'s inputs.
               The function should return an attribute set with modules, overlays, and
               specialArgs to be included across nixos and home manager configurations.
               Only attributes that are used should be returned.
@@ -141,8 +139,8 @@ let
           };
         overlays = mkOption {
           type = path;
-          default = "${userFlakeSelf}/overlays";
-          defaultText = "\${userFlakeSelf}/overlays";
+          default = "${self}/overlays";
+          defaultText = "\${self}/overlays";
           apply = x: lib.pathsToImportedAttrs (lib.pathsIn (toString x));
           description = ''
             path to folder containing overlays which will be applied to pkgs and exported in

--- a/lib/pkgs-lib/default.nix
+++ b/lib/pkgs-lib/default.nix
@@ -1,9 +1,13 @@
 { lib, nixpkgs, deploy, devshell }:
 
 lib.genAttrs
-  lib.defaultSystems (system:
+  lib.defaultSystems
+  (system:
+    let
+      pkgs = import nixpkgs { inherit system; };
+    in
     {
-      tests = import ./tests { inherit lib deploy nixpkgs system; };
+      tests = import ./tests { inherit lib deploy nixpkgs pkgs system; };
       shell = import ./shell { inherit lib devshell deploy nixpkgs system; };
     }
   )

--- a/lib/pkgs-lib/shell/default.nix
+++ b/lib/pkgs-lib/shell/default.nix
@@ -11,7 +11,7 @@ let
 
   ];
 
-  pkgs = import nixpkgs { inherit system overlays; config = {}; };
+  pkgs = import nixpkgs { inherit system overlays; config = { }; };
 
   flk = pkgs.callPackage ./flk.nix { };
 

--- a/lib/pkgs-lib/tests/default.nix
+++ b/lib/pkgs-lib/tests/default.nix
@@ -1,7 +1,5 @@
-{ lib, nixpkgs, deploy, system }:
+{ lib, nixpkgs, pkgs, deploy, system }:
 let
-  pkgs = import nixpkgs { inherit system; overlays = []; config = {}; };
-
   mkChecks = { hosts, nodes, homes ? { } }:
     let
       deployHosts = lib.filterAttrs
@@ -9,9 +7,10 @@ let
         nodes;
       deployChecks = deploy.lib.${system}.deployChecks { nodes = deployHosts; };
       tests =
-        lib.optionalAttrs (deployHosts != { }) {
-          profilesTest = profilesTest (hosts.${(builtins.head (builtins.attrNames deployHosts))});
-        } // lib.mapAttrs (n: v: v.activationPackage) homes;
+        lib.optionalAttrs (deployHosts != { })
+          {
+            profilesTest = profilesTest (hosts.${(builtins.head (builtins.attrNames deployHosts))});
+          } // lib.mapAttrs (n: v: v.activationPackage) homes;
 
     in
     lib.recursiveUpdate tests deployChecks;

--- a/lib/tests/default.nix
+++ b/lib/tests/default.nix
@@ -1,27 +1,27 @@
 { pkgs, lib }:
 
 pkgs.runCommandNoCC "devos-lib-tests"
-    {
-      buildInputs = [
-        pkgs.nix
-        (
-          let tests = import ./lib.nix { inherit pkgs lib; }; in
-            if tests == [ ] then null
-            else throw (builtins.toJSON tests)
-        )
-      ];
-    } ''
-    datadir="${pkgs.nix}/share"
-    export TEST_ROOT=$(pwd)/test-tmp
-    export NIX_BUILD_HOOK=
-    export NIX_CONF_DIR=$TEST_ROOT/etc
-    export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
-    export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
-    export NIX_STATE_DIR=$TEST_ROOT/var/nix
-    export NIX_STORE_DIR=$TEST_ROOT/store
-    export PAGER=cat
-    cacheDir=$TEST_ROOT/binary-cache
-    nix-store --init
+{
+  buildInputs = [
+    pkgs.nix
+    (
+      let tests = import ./lib.nix { inherit pkgs lib; }; in
+      if tests == [ ] then null
+      else throw (builtins.toJSON tests)
+    )
+  ];
+} ''
+  datadir="${pkgs.nix}/share"
+  export TEST_ROOT=$(pwd)/test-tmp
+  export NIX_BUILD_HOOK=
+  export NIX_CONF_DIR=$TEST_ROOT/etc
+  export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
+  export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
+  export NIX_STATE_DIR=$TEST_ROOT/var/nix
+  export NIX_STORE_DIR=$TEST_ROOT/store
+  export PAGER=cat
+  cacheDir=$TEST_ROOT/binary-cache
+  nix-store --init
 
-    touch $out
-  ''
+  touch $out
+''


### PR DESCRIPTION
Also format all files and add a flake.lock for lib

for a folder thats meant to work on other flakes theres never a reason it should need to refer to itself, only other flakes. So "self" and "inputs" are better namings for these variables. The userFlake* is redundant and confusing, when trying to call the functions its hard to figure out how to use them when there are two lines of arguments to figure out. 

Many of the functions don't even need this much information(ie mkHomeConfigurations and mkPkgs).

lib needs a flake.lock, because it is a flake we want others to  use. Also having to regenerate it every time its used makes no sense.

This also gets develop to pass `flake check` which it didn't because of deploy having a `utils.follows = "utils"`. 