### PR TITLE
profilesTest/mkHosts: include host's configuration

### DIFF
--- a/lib/devos/mkHosts.nix
+++ b/lib/devos/mkHosts.nix
@@ -90,7 +90,7 @@ let
       lib = {
         lib = { inherit specialArgs; };
         lib.testModule = {
-          imports = builtins.attrValues modules;
+          imports = [ local ] ++ builtins.attrValues modules;
         };
       };
     in

--- a/lib/pkgs-lib/tests/default.nix
+++ b/lib/pkgs-lib/tests/default.nix
@@ -48,7 +48,7 @@ let
     };
 
     testScript = ''
-      machine.systemctl("is-system-running --wait")
+      ${host.config.networking.hostName}.systemctl("is-system-running --wait")
     '';
   };
 


### PR DESCRIPTION
Now that profiles test is done dynamically - first available host - we likely need to include the host configuration itself. I have profiles that depend on the domain being set, which how I ran into this, and I think other problems might occur if we don't include the full host in the profiles test.

targeting core, since its a small bug fix and was planned to make into a release.