### PR TITLE
create lib.modules to store all devos modules

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,7 +81,7 @@
         "utils": "utils_2"
       },
       "locked": {
-        "narHash": "sha256-7Y6SqdLWr/g8tqNjqakRbS0KVIA/yzRm3D/RnoTAuzE=",
+        "narHash": "sha256-9mdO1eRrHz/3EAr3M8Ugdc8T6qWu4UbogafqO4mruKo=",
         "path": "./lib",
         "type": "path"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -81,7 +81,7 @@
         "utils": "utils_2"
       },
       "locked": {
-        "narHash": "sha256-9mdO1eRrHz/3EAr3M8Ugdc8T6qWu4UbogafqO4mruKo=",
+        "narHash": "sha256-IvKVn4U3Ts2aw8JoKvBCte6Z77JynuNob8LClmsopFo=",
         "path": "./lib",
         "type": "path"
       },

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -21,8 +21,7 @@ lib.nixosSystem (args // {
               # avoid unwanted systemd service startups
               # all strings in disabledModules get appended to modulesPath
               # so convert each to list which can be coerced to string
-              disabledModules = map (x: [ x ])
-                (lib.remove modules.core suites.allProfiles);
+              disabledModules = map lib.singleton suites.allProfiles;
 
               nix.registry = lib.mapAttrs (n: v: { flake = v; }) inputs;
 

--- a/lib/devos/devosSystem.nix
+++ b/lib/devos/devosSystem.nix
@@ -6,91 +6,19 @@ lib.nixosSystem (args // {
   modules =
     let
       moduleList = builtins.attrValues modules;
-      modpath = "nixos/modules";
 
       fullHostConfig = (lib.nixosSystem (args // { modules = moduleList; })).config;
 
       isoConfig = (lib.nixosSystem
         (args // {
           modules = moduleList ++ [
-
-            "${nixos}/${modpath}/installer/cd-dvd/installation-cd-minimal-new-kernel.nix"
-
-            ({ config, suites, ... }: {
-
-              # avoid unwanted systemd service startups
-              # all strings in disabledModules get appended to modulesPath
-              # so convert each to list which can be coerced to string
-              disabledModules = map lib.singleton suites.allProfiles;
-
-              nix.registry = lib.mapAttrs (n: v: { flake = v; }) inputs;
-
-              isoImage.isoBaseName = "nixos-" + config.networking.hostName;
-              isoImage.contents = [{
-                source = self;
-                target = "/devos/";
-              }];
-              isoImage.storeContents = [
-                self.devShell.${config.nixpkgs.system}
-                # include also closures that are "switched off" by the
-                # above profile filter on the local config attribute
-                fullHostConfig.system.build.toplevel
-              ];
-              # still pull in tools of deactivated profiles
-              environment.systemPackages = fullHostConfig.environment.systemPackages;
-
-              # confilcts with networking.wireless which might be slightly
-              # more useful on a stick
-              networking.networkmanager.enable = lib.mkForce false;
-              # confilcts with networking.wireless
-              networking.wireless.iwd.enable = lib.mkForce false;
-
-              # Set up a link-local boostrap network
-              # See also: https://github.com/NixOS/nixpkgs/issues/75515#issuecomment-571661659
-              networking.usePredictableInterfaceNames = lib.mkForce true; # so prefix matching works
-              networking.useNetworkd = lib.mkForce true;
-              networking.useDHCP = lib.mkForce false;
-              networking.dhcpcd.enable = lib.mkForce false;
-              systemd.network = {
-                # https://www.freedesktop.org/software/systemd/man/systemd.network.html
-                networks."boostrap-link-local" = {
-                  matchConfig = {
-                    Name = "en* wl* ww*";
-                  };
-                  networkConfig = {
-                    Description = "Link-local host bootstrap network";
-                    MulticastDNS = true;
-                    LinkLocalAddressing = "ipv6";
-                    DHCP = "yes";
-                  };
-                  address = [
-                    # fall back well-known link-local for situations where MulticastDNS is not available
-                    "fe80::47" # 47: n=14 i=9 x=24; n+i+x
-                  ];
-                  extraConfig = ''
-                    # Unique, yet stable. Based off the MAC address.
-                    IPv6LinkLocalAddressGenerationMode = "eui64"
-                  '';
-                };
-              };
-            })
+            (lib.modules.iso { inherit self nixos inputs fullHostConfig; })
           ];
         })).config;
       hmConfig = (lib.nixosSystem
         (args // {
           modules = moduleList ++ [
-            ({ config, ... }: {
-              home-manager.useUserPackages = lib.mkForce false;
-              home-manager.sharedModules = [
-                {
-                  home.sessionVariables = {
-                    inherit (config.environment.sessionVariables) NIX_PATH;
-                  };
-                  xdg.configFile."nix/registry.json".text =
-                    config.environment.etc."nix/registry.json".text;
-                }
-              ];
-            })
+            (lib.modules.hmConfig)
           ];
         })).config;
     in

--- a/lib/devos/mkHosts.nix
+++ b/lib/devos/mkHosts.nix
@@ -4,70 +4,18 @@
 let
   defaultSystem = "x86_64-linux";
 
-  experimentalFeatures = [
-    "flakes"
-    "nix-command"
-    "ca-references"
-    "ca-derivations"
-  ];
-
-  modules = {
-    modOverrides = { config, overrideModulesPath, ... }:
-      let
-        inherit (overrides) modules disabledModules;
-      in
-      {
-        disabledModules = modules ++ disabledModules;
-        imports = map
-          (path: "${overrideModulesPath}/${path}")
-          modules;
-      };
-
-    global = { config, pkgs, ... }: {
-      home-manager = {
-        useGlobalPkgs = true;
-        useUserPackages = true;
-
-        extraSpecialArgs = extern.userSpecialArgs // { suites = suites.user; };
-        sharedModules = extern.userModules ++ (builtins.attrValues self.homeModules);
-      };
-      users.mutableUsers = lib.mkDefault false;
-
-      hardware.enableRedistributableFirmware = lib.mkDefault true;
-
-      nix.nixPath = [
-        "nixpkgs=${nixos}"
-        "nixos-config=${self}/lib/compat/nixos"
-        "home-manager=${inputs.home}"
-      ];
-
-      nixpkgs.pkgs = lib.mkDefault multiPkgs.${config.nixpkgs.system};
-
-      nix.registry = {
-        devos.flake = self;
-        nixos.flake = nixos;
-        override.flake = inputs.override;
-      };
-
-      nix.package = pkgs.nixFlakes;
-
-      nix.extraOptions = ''
-        experimental-features = ${lib.concatStringsSep " "
-          experimentalFeatures
-        }
-      '';
-
-      system.configurationRevision = lib.mkIf (self ? rev) self.rev;
+  modules = with lib.modules; {
+    modOverrides = modOverrides { inherit overrides; };
+    hmDefaults = hmDefaults {
+      inherit extern;
+      inherit (self) homeModules;
+      userSuites = suites.user;
     };
-
-    # Everything in `./modules/list.nix`.
-    flakeModules = { imports = builtins.attrValues self.nixosModules ++ extern.modules; };
-
-    cachix = let rootCachix = "${self}/cachix.nix"; in
-      if builtins.pathExists rootCachix
-      then rootCachix
-      else { }
-    ;
+    globalDefaults = globalDefaults {
+      inherit self nixos inputs multiPkgs;
+    };
+    cachix = cachix { inherit self; };
+    flakeModules = flakeModules { inherit self extern; };
   };
 
   specialArgs = extern.specialArgs // { suites = suites.system; };

--- a/lib/flake.nix
+++ b/lib/flake.nix
@@ -16,6 +16,7 @@
           attrs = import ./attrs.nix { lib = nixpkgs.lib // self; };
           lists = import ./lists.nix { lib = nixpkgs.lib // self; };
           strings = import ./strings.nix { lib = nixpkgs.lib // self; };
+          modules = import ./modules.nix { lib = nixpkgs.lib // self; };
         in
 
         utils.lib
@@ -51,6 +52,7 @@
             filterPackages;
           inherit (lists) pathsIn;
           inherit (strings) rgxToString;
+          inherit modules;
         }
       );
 

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1,0 +1,74 @@
+{ lib }:
+{
+  modOverrides = { overrides }:
+    { config, overrideModulesPath, ... }:
+    let
+      inherit (overrides) modules disabledModules;
+    in
+    {
+      disabledModules = modules ++ disabledModules;
+      imports = map
+        (path: "${overrideModulesPath}/${path}")
+        modules;
+    };
+
+  hmDefaults = { userSuites, extern, homeModules }: {
+    home-manager = {
+      useGlobalPkgs = true;
+      useUserPackages = true;
+
+      extraSpecialArgs = extern.userSpecialArgs // { suites = userSuites; };
+      sharedModules = extern.userModules ++ (builtins.attrValues homeModules);
+    };
+  };
+
+  globalDefaults = { self, nixos, inputs, multiPkgs }:
+    let
+      experimentalFeatures = [
+        "flakes"
+        "nix-command"
+        "ca-references"
+        "ca-derivations"
+      ];
+    in
+    { config, pkgs, ... }: {
+      users.mutableUsers = lib.mkDefault false;
+
+      hardware.enableRedistributableFirmware = lib.mkDefault true;
+
+      nix.nixPath = [
+        "nixpkgs=${nixos}"
+        "nixos-config=${self}/lib/compat/nixos"
+        "home-manager=${inputs.home}"
+      ];
+
+      nixpkgs.pkgs = lib.mkDefault multiPkgs.${config.nixpkgs.system};
+
+      nix.registry = {
+        devos.flake = self;
+        nixos.flake = nixos;
+        override.flake = inputs.override;
+      };
+
+      nix.package = pkgs.nixFlakes;
+
+      nix.extraOptions = ''
+        experimental-features = ${lib.concatStringsSep " "
+          experimentalFeatures
+        }
+      '';
+
+      system.configurationRevision = lib.mkIf (self ? rev) self.rev;
+    };
+
+  cachix = { self }:
+    let rootCachix = "${self}/cachix.nix"; in
+    if builtins.pathExists rootCachix
+    then rootCachix
+    else { };
+
+  flakeModules = { self, extern }: { imports = builtins.attrValues self.nixosModules ++ extern.modules; };
+
+
+}
+

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -69,6 +69,80 @@
 
   flakeModules = { self, extern }: { imports = builtins.attrValues self.nixosModules ++ extern.modules; };
 
+  isoConfig = { self, nixos, inputs, fullHostConfig }:
+    { config, suites, ... }: {
 
+      imports = let modpath = "nixos/modules"; in
+        [ "${nixos}/${modpath}/installer/cd-dvd/installation-cd-minimal-new-kernel.nix" ];
+      # avoid unwanted systemd service startups
+      # all strings in disabledModules get appended to modulesPath
+      # so convert each to list which can be coerced to string
+      disabledModules = map lib.singleton suites.allProfiles;
+
+      nix.registry = lib.mapAttrs (n: v: { flake = v; }) inputs;
+
+      isoImage.isoBaseName = "nixos-" + config.networking.hostName;
+      isoImage.contents = [{
+        source = self;
+        target = "/devos/";
+      }];
+      isoImage.storeContents = [
+        self.devShell.${config.nixpkgs.system}
+        # include also closures that are "switched off" by the
+        # above profile filter on the local config attribute
+        fullHostConfig.system.build.toplevel
+      ];
+      # still pull in tools of deactivated profiles
+      environment.systemPackages = fullHostConfig.environment.systemPackages;
+
+      # confilcts with networking.wireless which might be slightly
+      # more useful on a stick
+      networking.networkmanager.enable = lib.mkForce false;
+      # confilcts with networking.wireless
+      networking.wireless.iwd.enable = lib.mkForce false;
+
+      # Set up a link-local boostrap network
+      # See also: https://github.com/NixOS/nixpkgs/issues/75515#issuecomment-571661659
+      networking.usePredictableInterfaceNames = lib.mkForce true; # so prefix matching works
+      networking.useNetworkd = lib.mkForce true;
+      networking.useDHCP = lib.mkForce false;
+      networking.dhcpcd.enable = lib.mkForce false;
+      systemd.network = {
+        # https://www.freedesktop.org/software/systemd/man/systemd.network.html
+        networks."boostrap-link-local" = {
+          matchConfig = {
+            Name = "en* wl* ww*";
+          };
+          networkConfig = {
+            Description = "Link-local host bootstrap network";
+            MulticastDNS = true;
+            LinkLocalAddressing = "ipv6";
+            DHCP = "yes";
+          };
+          address = [
+            # fall back well-known link-local for situations where MulticastDNS is not available
+            "fe80::47" # 47: n=14 i=9 x=24; n+i+x
+          ];
+          extraConfig = ''
+            # Unique, yet stable. Based off the MAC address.
+            IPv6LinkLocalAddressGenerationMode = "eui64"
+          '';
+        };
+      };
+    };
+
+  hmConfig =
+    { config, ... }: {
+      home-manager.useUserPackages = lib.mkForce false;
+      home-manager.sharedModules = [
+        {
+          home.sessionVariables = {
+            inherit (config.environment.sessionVariables) NIX_PATH;
+          };
+          xdg.configFile."nix/registry.json".text =
+            config.environment.etc."nix/registry.json".text;
+        }
+      ];
+    };
 }
 


### PR DESCRIPTION
Currently devosSystem and mkHosts a few modules in themselves. This ends up with them containing lots of code thats not directly related to its purpose. So I extracted those modules into their own file `lib/modules.nix` and namespace `lib.modules`. Each attribute is a module or a function to a module to describe what each module depends on. These are then used in devosSystem and mkHosts.

This should make rebase on fup easier, you can just drop lines in each module or remove unnecessary dependencies much easier if they have their own dedicated file.