### PR TITLE
pkgs-lib/shell: sudo nixos-generate-config

### DIFF
--- a/lib/pkgs-lib/shell/flk.sh
+++ b/lib/pkgs-lib/shell/flk.sh
@@ -33,7 +33,8 @@ case "$1" in
   "up")
     mkdir -p "$DEVSHELL_ROOT/up"
 
-    nixos-generate-config --dir "$DEVSHELL_ROOT/up/$HOSTNAME"
+    # `sudo` is necessary for `btrfs subvolume show`
+    sudo nixos-generate-config --dir "$DEVSHELL_ROOT/up/$HOSTNAME"
 
     printf "%s\n" \
       "{ suites, ... }:" \


### PR DESCRIPTION
```
$ btrfs subvol show / >/dev/null; printf "%s\n" "$?"
ERROR: Could not search B-tree: Operation not permitted
1
```

Btrfs's `ioctl()` `BTRFS_IOC_TREE_SEARCH` requires elevation. `btrfs subvol show <path>` may be called by `nixos-generate-config`, and if `btrfs subvol show <path>` fails then `nixos-generate-config` fails.