### PR TITLE
default.nix: fix path to compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 let
   inherit (default.inputs.nixos) lib;
 
-  default = (import "${./lib}/compat").defaultNix;
+  default = (import ./lib/compat).defaultNix;
 
   ciSystems = [
     "aarch64-linux"


### PR DESCRIPTION
Looks like it was just a path error.

fixes #285 