### PR TITLE
ref: pass our lib as lib.our to the module system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
           channelName = "nixos";
           modules = ./modules/module-list.nix;
           externalModules = [
-            { _module.args.ourLib = self.lib; }
+            { lib.our = self.lib; }
             ci-agent.nixosModules.agent-profile
             home.nixosModules.home-manager
             agenix.nixosModules.age


### PR DESCRIPTION
At least we don't find ourselves with strange module signatures
and use something that looks like a dedicated namespace within
he module system: `config.lib`

---

```shell
➜  devos git:(da/pass-lib-as-config-lib) rg ourLib
➜  devos git:(da/pass-lib-as-config-lib) # nothing found
```