### PR TITLE
Fix: Haskell overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,6 @@
             nur.overlay
             agenix.overlay
             nvfetcher.overlay
-            (final: prev: { nvfetcher-bin = nvfetcher.defaultPackage.${final.system}; })
             ./pkgs/default.nix
           ];
         };

--- a/overlays/overrides.nix
+++ b/overlays/overrides.nix
@@ -14,15 +14,15 @@ channels: final: prev: {
     starship;
 
 
-  haskellPackages = prev.haskellPackages.override {
-    overrides = hfinal: hprev:
-      let version = prev.lib.replaceChars [ "." ] [ "" ] prev.ghc.version;
-      in
-      {
-        # same for haskell packages, matching ghc versions
-        inherit (channels.latest.haskell.packages."ghc${version}")
-          haskell-language-server;
-      };
-  };
-
+  haskellPackages = prev.haskellPackages.override
+    (old: {
+      overrides = prev.lib.composeExtensions (old.overrides or (_: _: { })) (hfinal: hprev:
+        let version = prev.lib.replaceChars [ "." ] [ "" ] prev.ghc.version;
+        in
+        {
+          # same for haskell packages, matching ghc versions
+          inherit (channels.latest.haskell.packages."ghc${version}")
+            haskell-language-server;
+        });
+    });
 }


### PR DESCRIPTION
using `lib.composeExtensions` for packageOverrides is more idiomatic.
Fixes: https://github.com/divnix/devos/pull/325#pullrequestreview-687772802
such as 
```
 python3 = pkgs.python3.override (old: {
   5 │ │ packageOverrides =
   4 │ │ │ pkgs.lib.composeExtensions
   3 │ │ │ │ (old.packageOverrides or (_: _: { }))
   2 │ │ │ │ packageOverrides;
   1 │ });
```