### PR TITLE
core: use bottom instead of gotop

### DIFF
--- a/profiles/core/default.nix
+++ b/profiles/core/default.nix
@@ -17,7 +17,7 @@ in
       dosfstools
       fd
       git
-      gotop
+      bottom
       gptfdisk
       iputils
       jq
@@ -84,7 +84,7 @@ in
         se = ifSudo "sudoedit";
 
         # top
-        top = "gotop";
+        top = "btm";
 
         # systemd
         ctl = "systemctl";


### PR DESCRIPTION
gotop is unmaintained, unless someone has a better alternative, it looks like bottom is the new goto