### PR TITLE
imp: add portable user definition

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,6 +159,9 @@
         "deploy": "deploy",
         "devshell": "devshell",
         "flake-utils": "flake-utils",
+        "home-manager": [
+          "home"
+        ],
         "nixlib": [
           "nixos"
         ],
@@ -169,11 +172,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1626404753,
-        "narHash": "sha256-Ag/e7tecRg19FS+B5kKXu3KTwiNlM/C8saofKvYPC8A=",
+        "lastModified": 1626451343,
+        "narHash": "sha256-TXHFFYJhkMknpb1l0nuCfHtOMLNabAKYY5XE2p8HFM0=",
         "owner": "divnix",
         "repo": "digga",
-        "rev": "ed0dc961c121db31ac05d19937e1482ce55ff599",
+        "rev": "37e5542b03e5da27ff7d2ed801fa118c2b87bf02",
         "type": "github"
       },
       "original": {
@@ -454,11 +457,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1624737817,
-        "narHash": "sha256-styqXE6Xli61dnDst0vB0Kb1tPt/aCuxOhTK0uGDCng=",
+        "lastModified": 1626288344,
+        "narHash": "sha256-TioHDqWJkw37jjx4DVrH6LCzwrUfAqXbWl4rKR91fpA=",
         "owner": "gytis-ivaskevicius",
         "repo": "flake-utils-plus",
-        "rev": "6bf0d314fc5623d5d4b5240ee0bf0a3a270d717c",
+        "rev": "5c6ee69f6957afc2fe22c094717d6d78516418b5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,7 @@
       digga.url = "github:divnix/digga/develop";
       digga.inputs.nixpkgs.follows = "nixos";
       digga.inputs.nixlib.follows = "nixos";
+      digga.inputs.home-manager.follows = "home";
 
       bud.url = "github:divnix/bud";
       bud.inputs.nixpkgs.follows = "nixos";
@@ -136,6 +137,9 @@
             base = [ direnv git ];
           };
         };
+        users = {
+          nixos = { suites, ... }: { imports = suites.base; };
+        }; # digga.lib.importers.rakeLeaves ./users/hm;
       };
 
       devshell.modules = [ (import ./shell bud') ];

--- a/users/nixos/default.nix
+++ b/users/nixos/default.nix
@@ -1,8 +1,6 @@
-{ ... }:
+{ hmUsers, ... }:
 {
-  home-manager.users.nixos = { suites, ... }: {
-    imports = suites.base;
-  };
+  home-manager.users = { inherit (hmUsers) nixos; };
 
   users.users.nixos = {
     uid = 1000;


### PR DESCRIPTION
According to https://github.com/nix-community/home-manager/issues/2161
there might be a better formal distinction between host-spaced and
portable arch-spaced hm users in the future.
