### PR TITLE
Automatically build sources

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,36 @@
     , deploy
     , ...
     } @ inputs:
+
+    let
+      rakePkgs = dir:
+        let
+          sieve = name: val:
+            (name != "default" && name != "bud" && name != "_sources");
+
+          flattenFiltered = digga.lib.flattenTree
+            (nixos.lib.filterAttrs sieve (digga.lib.rakeLeaves dir));
+          getBasename = name: nixos.lib.last (nixos.lib.splitString "." name);
+        in
+        nixos.lib.mapAttrs' (n: v: nixos.lib.nameValuePair (getBasename n) v)
+          flattenFiltered;
+
+      localPackages = final: prev:
+        builtins.mapAttrs
+          (name: value:
+            let
+              sources = (import ./pkgs/_sources/generated.nix) {
+                inherit (prev) fetchurl fetchgit;
+              };
+              package = import (value);
+              args = builtins.intersectAttrs (builtins.functionArgs package) {
+                source = sources.${name};
+              };
+            in
+            final.callPackage package args)
+          (rakePkgs (./pkgs));
+
+    in
     digga.lib.mkFlake
       {
         inherit self inputs;
@@ -78,6 +108,7 @@
               agenix.overlay
               nvfetcher.overlay
               deploy.overlay
+              localPackages
               ./pkgs/default.nix
             ];
           };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,5 +1,29 @@
-final: prev: {
-  # keep sources this first
-  sources = prev.callPackage (import ./_sources/generated.nix) { };
-  # then, call packages with `final.callPackage`
+self: super:
+let
+  sources = (import ./_sources/generated.nix) { inherit (self) fetchurl fetchgit; };
+
+  mkVimPlugin = plugin:
+    self.vimUtils.buildVimPluginFrom2Nix {
+      inherit (plugin) pname version src;
+    };
+
+  newPkgsSet = pkgSet:
+    let
+      prefix = "${pkgSet}-";
+
+      pkgSetBuilder = {
+        "vimPlugins" = mkVimPlugin;
+      }.${pkgSet};
+
+
+      pkgsInSources = self.lib.mapAttrs' (name: value: self.lib.nameValuePair (self.lib.removePrefix prefix name) (value)) (self.lib.filterAttrs (n: v: self.lib.hasPrefix prefix n) sources);
+    in
+    self.lib.mapAttrs (n: v: pkgSetBuilder v) pkgsInSources;
+
+in
+{
+  inherit sources;
+
+  vimPlugins = super.vimPlugins // (newPkgsSet "vimPlugins");
+
 }


### PR DESCRIPTION
This pull request does a couple things.

1. Any package inside `./pkgs` (with the exception of `./pkgs/bud`, `./pkgs/_sources` and `./pkgs/default.nix` will be called (as in `callPackage`) and can use `inherit (source) pname version src` so long as the name of parent folder for the `default.nix` or the name of the nix file stripped of .nix is the same name used in `sources.toml`
2. Start work on automatically building vimPlugins, vscode extension, and other development tools from prefixes in `sources.toml` Currently only vimPlugins are implemented.

I recognize that `flake.nix` is not a great place for an overlay. I was unable to find a way to make an overlay that lets you import inputs, which means defining rakeTree and flattenTree before writing what's currently in the flake. It would also have had to be used as `(import ./path/filename.nix).overlay`.