### PR TITLE
Chore

### DIFF
--- a/bud/default.nix
+++ b/bud/default.nix
@@ -6,5 +6,11 @@
       help = "Copy the desired template to DEST";
       script = ./get.bash;
     };
+    nvfetcher-github = {
+      writer = budUtils.writeBashWithPaths [ nvfetcher-bin coreutils git ];
+      synopsis = "nvfetcher-github";
+      help = "Auto update with nvfetcher on github action";
+      script = ./nvfetcher-github.bash;
+    };
   };
 }

--- a/bud/nvfetcher-github.bash
+++ b/bud/nvfetcher-github.bash
@@ -1,0 +1,20 @@
+cd $FLAKEROOT/pkgs
+nvfetcher -c ./sources.toml -l changelog --no-output
+if [ ! -z "$(cat changelog)" ]; then
+  echo "COMMIT_MSG<<EOF" >>$GITHUB_ENV
+  echo "$(cat changelog)" >>$GITHUB_ENV
+  echo "EOF" >>$GITHUB_ENV
+  rm -rf changelog
+else
+  rm -rf changelog
+fi
+# Github Action Template
+# schedule:
+# - cron: '0 7 * * *'
+# - name: Run nvfetcher
+#   run: nix -Lv develop --command bud nvfetcher-github
+# - name: Commit changes
+#   if: ${{ env.COMMIT_MSG != null }}
+#   uses: stefanzweifel/git-auto-commit-action@v4
+#   with:
+#     commit_message: ${{ env.COMMIT_MSG }}

--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1624890984,
-        "narHash": "sha256-RMQtTm4OoEc8BHWk4/Yfu1y4uHlG4HCP+DeC0J0zGqQ=",
+        "lastModified": 1627523399,
+        "narHash": "sha256-j9CgnUQpWcb8OB4LRzPW8BdxvmoROJptgptDlPA8Heo=",
         "owner": "berberman",
         "repo": "nvfetcher",
-        "rev": "d3efa8c58057dbcc1565dca3105d31d9f25fd5ca",
+        "rev": "fb8f2cc770ad3dd3e29d7ba3004692d4d53fba9b",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -12,6 +12,5 @@
       leaveDotGit = false;
       sha256 = "1b7xi8c2drbwzfz70czddc4j33s7g1alirv12dwl91hbqxifx8qs";
     };
-
   };
 }

--- a/shell/devos.nix
+++ b/shell/devos.nix
@@ -41,7 +41,7 @@ in
       category = "devos";
       name = pkgs.nvfetcher-bin.pname;
       help = pkgs.nvfetcher-bin.meta.description;
-      command = "cd $DEVSHELL_ROOT/pkgs; ${pkgs.nvfetcher-bin}/bin/nvfetcher -c ./sources.toml --no-output $@; nixpkgs-fmt _sources/";
+      command = "cd $DEVSHELL_ROOT/pkgs; ${pkgs.nvfetcher-bin}/bin/nvfetcher -c ./sources.toml --no-output $@";
     }
     (linter nixpkgs-fmt)
     (linter editorconfig-checker)

--- a/users/profiles/direnv/default.nix
+++ b/users/profiles/direnv/default.nix
@@ -1,6 +1,9 @@
 {
   programs.direnv = {
     enable = true;
-    nix-direnv.enable = true;
+    nix-direnv = {
+      enable = true;
+      enableFlakes = true;
+    };
   };
 }


### PR DESCRIPTION
We don't need the nixpkgs-fmt for nvfetcher anymore, and it has been fixed upstream. 