### PR TITLE
Replace references to `flk` and `core` with `bud` and `master`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,4 +35,4 @@ Please search on the [issue tracker](../) before creating one.
 
 ## Your Environment
 <!--- Include relevant details about the environment you experienced the bug in. -->
-<!--- If you have run `flk update`, for example, post the flake.lock file. -->
+<!--- If you have run `bud update`, for example, post the flake.lock file. -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          ref: core
+          ref: master
       - name: Update Changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.1.1
         with:
@@ -49,7 +49,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          ref: core
+          ref: master
 
       - name: Get Changelog Entry
         id: changelog_reader

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ result
 .direnv
 doc/index.html
 
-# Result of flk commands
+# Result of bud commands
 vm
 iso
 doi

--- a/bud/get.bash
+++ b/bud/get.bash
@@ -1,1 +1,1 @@
-nix flake new -t "github:divnix/devos/core" "${2:-devos}"
+nix flake new -t "github:divnix/devos/master" "${2:-devos}"

--- a/doc/concepts/profiles.md
+++ b/doc/concepts/profiles.md
@@ -63,5 +63,5 @@ specific belongs in your [host](hosts.md) files instead.
 [definition]: https://nixos.org/manual/nixos/stable/index.html#sec-option-definitions
 [declaration]: https://nixos.org/manual/nixos/stable/index.html#sec-option-declarations
 [options]: https://nixos.org/manual/nixos/stable/index.html#sec-writing-modules
-[spec]: https://github.com/divnix/devos/tree/core/lib/devos/mkProfileAttrs.nix
+[spec]: https://github.com/divnix/devos/tree/master/lib/devos/mkProfileAttrs.nix
 [config]: https://nixos.wiki/wiki/Module#structure

--- a/doc/concepts/users.md
+++ b/doc/concepts/users.md
@@ -73,5 +73,5 @@ nix build "github:divnix/devos#homeConfigurations.nixos@NixOS.home.activationPac
 ```
 
 [home-manager]: https://nix-community.github.io/home-manager
-[modules-list]: https://github.com/divnix/devos/tree/core/users/modules/module-list.nix
+[modules-list]: https://github.com/divnix/devos/tree/master/users/modules/module-list.nix
 [portableuser]: https://digga.divnix.com/api-reference-home.html#homeusers

--- a/doc/concepts/users.md
+++ b/doc/concepts/users.md
@@ -48,7 +48,7 @@ argument that gets passed to your home-manager users.
 
 ## External Usage
 You can easily use the defined home-manager configurations outside of NixOS
-using the `homeConfigurations` flake output. The [flk](../flk/index.md) helper
+using the `homeConfigurations` flake output. The [bud](../bud/index.md) helper
 script makes this even easier.
 
 This is great for keeping your environment consistent across Unix systems,
@@ -57,10 +57,10 @@ including OSX.
 ### From within the projects devshell:
 ```sh
 # builds the nixos user defined in the NixOS host
-flk home NixOS nixos
+bud home NixOS nixos
 
 # build and activate
-flk home NixOS nixos switch
+bud home NixOS nixos switch
 ```
 
 ### Manually from outside the project:

--- a/doc/integrations/deploy.md
+++ b/doc/integrations/deploy.md
@@ -40,7 +40,7 @@ And the private key to your user:
 
 And run the deployment:
 ```sh
-deploy "bud#hostName" --hostname host.example.com
+deploy ".#hostName" --hostname host.example.com
 ```
 
 > ##### _Note:_

--- a/doc/integrations/deploy.md
+++ b/doc/integrations/deploy.md
@@ -40,7 +40,7 @@ And the private key to your user:
 
 And run the deployment:
 ```sh
-deploy "flk#hostName" --hostname host.example.com
+deploy "bud#hostName" --hostname host.example.com
 ```
 
 > ##### _Note:_

--- a/doc/integrations/deploy.md
+++ b/doc/integrations/deploy.md
@@ -40,7 +40,7 @@ And the private key to your user:
 
 And run the deployment:
 ```sh
-deploy ".#hostName" --hostname host.example.com
+deploy '.#hostName' --hostname host.example.com
 ```
 
 > ##### _Note:_

--- a/doc/integrations/nvfetcher.md
+++ b/doc/integrations/nvfetcher.md
@@ -40,4 +40,4 @@ fetch.git = "https://github.com/mlvzk/manix.git" # responsible for fetching
 
 [nvf]: https://github.com/berberman/nvfetcher
 [nvf-readme]: https://github.com/berberman/nvfetcher#readme
-[sources.toml]: https://github.com/divnix/devos/tree/core/pkgs/sources.toml
+[sources.toml]: https://github.com/divnix/devos/tree/master/pkgs/sources.toml

--- a/doc/start/from-nixos.md
+++ b/doc/start/from-nixos.md
@@ -4,7 +4,7 @@
 Assuming you're happy with your existing partition layout, you can generate a
 basic NixOS configuration for your system using:
 ```sh
-flk up
+bud up
 ```
 
 This will make a new file `hosts/up-$(hostname).nix`, which you can edit to
@@ -38,7 +38,7 @@ Now might be a good time to read the docs on [suites](../concepts/suites.md) and
 
 Once you're ready to deploy `hosts/my-host.nix`:
 ```sh
-flk my-host switch
+bud my-host switch
 ```
 
 

--- a/doc/start/index.md
+++ b/doc/start/index.md
@@ -6,10 +6,10 @@ Here is a snippet that will get you the template without the git history:
 ```sh
 nix-shell -p cachix --run "cachix use nrdxp"
 
-nix-shell https://github.com/divnix/devos/archive/core.tar.gz -A shell \
-  --run "flk get core"
+nix-shell https://github.com/divnix/devos/archive/master.tar.gz -A shell \
+  --run "bud get master"
 
-cd flk
+cd bud
 
 nix-shell
 
@@ -18,7 +18,7 @@ git add .
 git commit -m init
 ```
 
-This will place you in a new folder named `flk` with git initialized, and a
+This will place you in a new folder named `bud` with git initialized, and a
 nix-shell that provides all the dependencies, including the unstable nix
 version required.
 

--- a/doc/start/index.md
+++ b/doc/start/index.md
@@ -9,7 +9,7 @@ nix-shell -p cachix --run "cachix use nrdxp"
 nix-shell https://github.com/divnix/devos/archive/master.tar.gz -A shell \
   --run "bud get master"
 
-cd bud
+cd devos
 
 nix-shell
 
@@ -18,7 +18,7 @@ git add .
 git commit -m init
 ```
 
-This will place you in a new folder named `bud` with git initialized, and a
+This will place you in a new folder named `devos` with git initialized, and a
 nix-shell that provides all the dependencies, including the unstable nix
 version required.
 

--- a/doc/tests.md
+++ b/doc/tests.md
@@ -26,7 +26,7 @@ and the examples in [nixpkgs][nixos-tests].
 
 [test-doc]: https://nixos.org/manual/nixos/stable/index.html#sec-nixos-tests
 [test-blog]: https://www.haskellforall.com/2020/11/how-to-use-nixos-for-lightweight.html
-[default]: https://github.com/divnix/devos/tree/core/tests/default.nix
+[default]: https://github.com/divnix/devos/tree/master/tests/default.nix
 [run-test]: https://github.com/NixOS/nixpkgs/blob/6571462647d7316aff8b8597ecdf5922547bf365/lib/debug.nix#L154-L166
 [nixos-tests]: https://github.com/NixOS/nixpkgs/tree/master/nixos/tests
 [testing-python]: https://github.com/NixOS/nixpkgs/tree/master/nixos/lib/testing-python.nix


### PR DESCRIPTION
Fixes #366 

~Blocked by #369 — the docs cannot be updated until the docs workflow is running again. The site hasn't been built since last month despite other recent updates to docs on `master`.~ ✅ 