### PR TITLE
Trigger CI workflows on pushes to both `main` and `master` + Update PR target branch guideline

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - master
       - trying
       - staging
 jobs:

--- a/.github/workflows/mdbook_docs.yml
+++ b/.github/workflows/mdbook_docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
 
 jobs:
   deploy:

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Pull Requests
 
 ## TL;DR;
-- **Target Branch**: `main`
+- **Target Branch**: `master`
 - **Merge Policy**: [`bors`][bors] is always right (&rarr; `bors try`)
 - **Docs**: every changeset is expected to contain doc updates
 - **Commit Msg**: be a poet! Comprehensive and explanatory commit messages 


### PR DESCRIPTION
Addresses the broken CI workflows mentioned in #369 by allowing workflow triggers on pushes to the `master` branch since `main` doesn't exist. This does not necessarily mean #369 can be closed since ideally `master` will be replaced with `main` entirely.