### PR TITLE
Remove lingering references to `main` in workflow configs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,6 @@ name: "Check & Cachix"
 on:
   push:
     branches:
-      - main
       - master
       - trying
       - staging

--- a/.github/workflows/mdbook_docs.yml
+++ b/.github/workflows/mdbook_docs.yml
@@ -3,7 +3,6 @@ name: Deploy Docs to GitHub Pages
 on:
   push:
     branches:
-      - main
       - master
 
 jobs:


### PR DESCRIPTION
See #369

I should have removed these in #371 