### PR TITLE
Fix outdated option name

### DIFF
--- a/doc/concepts/users.md
+++ b/doc/concepts/users.md
@@ -37,9 +37,10 @@ User profiles can be collected in a similar fashion as system ones into a `suite
 argument that gets passed to your home-manager users.
 
 ### Example
+`flake.nix`
 ```nix
 {
-  home-manager.users.nixos = { suites, ... }: {
+  home.users.nixos = { suites, ... }: {
     imports = suites.base;
   };
 }


### PR DESCRIPTION
While muddling through #381, I realized the docs had a reference to an option that had been renamed.

I'm not sure yet whether any changes should be made to the example in the previous section, as the default seems to be to pull stuff in from `hmUsers` rather than directly specifying options like the example does, but I'm not sure what we'd consider best practice there.