### PR TITLE
Remove git crypt, update docs

### DIFF
--- a/doc/secrets.md
+++ b/doc/secrets.md
@@ -1,10 +1,7 @@
 # Secrets
-Secrets are managed using [git-crypt][git-crypt] and [agenix][agenix]
+Secrets are managed using [agenix][agenix]
 so you can keep your flake in a public repository like GitHub without
 exposing your password or other sensitive data.
-
-By default, everything in the secrets folder is automatically encrypted. Just
-be sure to run `git-crypt init` before putting anything in here.
 
 ## Agenix
 Currently, there is [no mechanism][secrets-issue] in nix itself to deploy secrets
@@ -104,7 +101,6 @@ secrets get decrypted. You can learn about them by looking at the
 > You can take a look at the [agenix repository][agenix] for more information
 > about the tool.
 
-[git-crypt]: https://github.com/AGWA/git-crypt
 [agenix]: https://github.com/ryantm/agenix
 [age module]: https://github.com/ryantm/agenix/blob/master/modules/age.nix
 [secrets-issue]: https://github.com/NixOS/nix/issues/8

--- a/secrets/.gitattributes
+++ b/secrets/.gitattributes
@@ -1,4 +1,0 @@
-* filter=git-crypt diff=git-crypt
-.gitattributes !filter !diff
-secrets.nix !filter !diff
-README.md !filter !diff

--- a/shell/devos.nix
+++ b/shell/devos.nix
@@ -30,10 +30,6 @@ in
     unset _PATH
   '');
 
-  packages = with pkgs; [
-    git-crypt
-  ];
-
   commands = with pkgs; [
     (devos nixUnstable)
     (devos agenix)


### PR DESCRIPTION
`git crypt` is rather hard to use, and overlaps with `agenix` in a lot of circumstances. Using both of them at the same time can result in double-encrypted files, causing issues that are hard to debug. This PR removes git-crypt from the installation and documentation, favoring agenix instead.