### PR TITLE
Do not hardcode UID for the exemplary user

### DIFF
--- a/users/nixos/default.nix
+++ b/users/nixos/default.nix
@@ -3,7 +3,6 @@
   home-manager.users = { inherit (hmUsers) nixos; };
 
   users.users.nixos = {
-    uid = 1000;
     password = "nixos";
     description = "default";
     isNormalUser = true;


### PR DESCRIPTION
`uid = 1000` is an unreasonable default for an examplary user nixos, because someone trying DevOs on a working NixOS installation likely has their own user with uid = 1000 already. The code thus renders `/etc/passwd` invalid preventing user from logging in