### PR TITLE
remove anti-corruption layer

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,15 +39,6 @@
       naersk.inputs.nixpkgs.follows = "latest";
 
       nixos-hardware.url = "github:nixos/nixos-hardware";
-
-      # start ANTI CORRUPTION LAYER
-      # remove after https://github.com/NixOS/nix/pull/4641
-      nixpkgs.follows = "nixos";
-      nixlib.follows = "digga/nixlib";
-      blank.follows = "digga/blank";
-      flake-utils-plus.follows = "digga/flake-utils-plus";
-      flake-utils.follows = "digga/flake-utils";
-      # end ANTI CORRUPTION LAYER
     };
 
   outputs =


### PR DESCRIPTION
https://github.com/NixOS/nix/pull/4641 got merged, so this should probably be safe to remove? @blaggacao 