### PR TITLE
Fix decryption location for agenix in documentation

### DIFF
--- a/doc/secrets.md
+++ b/doc/secrets.md
@@ -14,7 +14,7 @@ to easily setup those secret files declaratively.
 [agenix][agenix] encrypts secrets and stores them as .age files in your repository.
 Age files are encrypted with multiple ssh public keys, so any host or user with a
 matching ssh private key can read the data. The [age module][age module] will add those
-encrypted files to the nix store and decrypt them on activation to `/run/secrets`.
+encrypted files to the nix store and decrypt them on activation to `/run/agenix`.
 
 ### Setup
 All hosts must have openssh enabled, this is done by default in the core profile.


### PR DESCRIPTION
Fix the documentation so that no one else runs into what I did #425 